### PR TITLE
Make python dependencies in Dockerfile versionless

### DIFF
--- a/v2g-liberty/Dockerfile
+++ b/v2g-liberty/Dockerfile
@@ -16,12 +16,12 @@ COPY rootfs/patches /patches
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
-        python3-dev=3.11.10-r0 \
+        python3-dev \
     \
     && apk add --no-cache \
-        py3-pip=23.3.1-r0 \
-        py3-wheel=0.42.0-r0 \
-        python3=3.11.10-r0 \
+        py3-pip \
+        py3-wheel \
+        python3 \
     \
     && pip install -r /tmp/requirements.txt \
     \


### PR DESCRIPTION
Recently we had some problems with building the Docker container. 
This is caused by an updated of the python packages in the alipine repository that this addon builds on top of.
Since the Dockerfile mentions explicit versions, these versions are no longer available after the update of the external repository, causing this build problem.
Since the only way to fix the problem, is to update the Dockerfile with the new version, I do not see the added value of explicitly naming the version.