### PR TITLE
#68 All calls to FM via FM client:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,40 @@ The next release might include:
 
 ### Adding
 
-- None.
+- ?
 
 
 ### Changing
 
-- Use flexmeasures_client python library for all calls to FM
+- ?
 
 ### Removing
 
 - ?
+
+
+## 0.2.1 2024-09-??
+
+### Added
+
+- None
+
+### Fixed
+
+- 🪲 BUG: Too frequent fluctuating (scheduled) charge power (#74)
+
+
+### Changed
+
+- Use flexmeasures_client python library for all calls to FM
+  This makes getting schedules and other data (much) faster.
+- Made python dependencies in Dockerfile versionless.
+- Renamed set_fm_data to data_monitor, this reflects its function better.
+
+### Removed
+
+- None
+
 
 
 ## 0.2.0 2024-08-28

--- a/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -11,6 +11,9 @@ mkdir -p /config/logs
 # Remove old flexmeasures_client.py as it has the same name as the pypi library
 rm -f /config/apps/v2g-liberty/flexmeasures_client.py
 
+# V0.2.1 2024-089-10 Remove old set_fm_data.py as it has been renamed to data_monitor.py
+rm -f /config/apps/v2g-liberty/set_fm_data.py
+
 # Copy python files
 cp -aRv /root/appdaemon/* /config \
     || bashio::exit.nok 'Failed to copy V2G-Liberty app'

--- a/v2g-liberty/rootfs/root/appdaemon/apps/apps.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/apps.yaml
@@ -36,6 +36,14 @@ v2g_liberty:
     - modbus_evse_client
     - reservations-client
 
+data_monitor:
+  module: data_monitor
+  class: DataMonitor
+  priority: 75
+  dependencies:
+    - v2g-globals
+    - modbus_evse_client
+
 get_fm_data:
   module: get_fm_data
   class: FlexMeasuresDataImporter
@@ -44,21 +52,13 @@ get_fm_data:
    - v2g-globals
    - fm_client
 
-set_fm_data:
-  module: set_fm_data
-  class: SetFMdata
-  priority: 75
-  dependencies:
-    - v2g-globals
-    - modbus_evse_client
-
 amber_price_data_manager:
   module: amber_price_data_manager
   class: ManageAmberPriceData
   priority: 100
   dependencies:
     - v2g-globals
-    - set_fm_data
+    - fm_client
 
 octopus_price_data_manager:
   module: octopus_price_data_manager
@@ -66,4 +66,4 @@ octopus_price_data_manager:
   priority: 100
   dependencies:
     - v2g-globals
-    - set_fm_data
+    - fm_client

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/constants.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/constants.py
@@ -51,29 +51,19 @@ ALLOWED_DURATION_ABOVE_MAX_SOC: int = 12
 
 OPTIMISATION_MODE: str = "price"
 ELECTRICITY_PROVIDER: str = "nl_generic"
+EMISSIONS_UOM: str = "kg/MWh"    # For some ELECTRICITY_PROVIDER-s this can be %
+CURRENCY: str = "EUR"            # For some ELECTRICITY_PROVIDER-s this can be different, e.g. GBP or AUD.
+PRICE_RESOLUTION_MINUTES: int = 60  # For some ELECTRICITY_PROVIDER-s this can be 30
 
 # FlexMeasures settings
 
 # This represents how often schedules should refresh. Keep at this setting.
-FM_EVENT_RESOLUTION_IN_MINUTES = 5
+FM_EVENT_RESOLUTION_IN_MINUTES: int = 5
+EVENT_RESOLUTION: object # Should be timedelta but do not want to import that here, see globals.
 
 # CONSTANTS for FM URL's
 FM_BASE_URL = "https://seita.energy"
-FM_API_VERSION = "v3_0"
-
-# Set through globals based on FM_BASE_URL
-# TODO: Use fm_client so than many of these do not need to be administered here any more.
-FM_BASE_API_URL: str = ""
-FM_PING_URL: str = ""
-FM_AUTHENTICATION_URL: str = ""
-FM_SENSOR_URL: str = ""
-FM_SCHEDULE_SLUG: str = ""
-FM_SCHEDULE_TRIGGER_SLUG: str = ""
-FM_GET_DATA_URL: str = ""
-FM_GET_DATA_SLUG: str = ""
-FM_SET_DATA_URL: str = ""
-FM_TRIGGER_URL: str = ""
-FM_GET_SCHEDULE_URL: str = ""
+# Based on ELECTRICITY_PROVIDER
 FM_OPTIMISATION_CONTEXT: dict = {}
 
 # Utility context
@@ -98,27 +88,15 @@ FM_ACCOUNT_PASSWORD: str = ""
 
 # Sensor entity for sending and id for retrieving data to/from FM
 FM_ACCOUNT_POWER_SENSOR_ID: int = 0
-FM_ENTITY_ADDRESS_POWER: str = ""
-
-# Sensor entity for sending and id for retrieving data to/from FM
 FM_ACCOUNT_AVAILABILITY_SENSOR_ID: int = 0
-FM_ENTITY_ADDRESS_AVAILABILITY: str = ""
-
-# Sensor entity for sending and id for retrieving data to/from FM
 FM_ACCOUNT_SOC_SENSOR_ID: int = 0
-FM_ENTITY_ADDRESS_SOC: str = ""
-
-# Sensor_id for retrieving data from FM
 FM_ACCOUNT_COST_SENSOR_ID: int = 0
 
 # Sensors for optimisation context, also in case prices are self_provided (e.g. au_amber_electric)
 # Sensor entity for sending and id for retrieving data to/from FM
 FM_PRICE_PRODUCTION_SENSOR_ID: int = 0
-FM_PRICE_PRODUCTION_ENTITY_ADDRESS: str = ""
 FM_PRICE_CONSUMPTION_SENSOR_ID: int = 0
-FM_PRICE_CONSUMPTION_ENTITY_ADDRESS: str = ""
 FM_EMISSIONS_SENSOR_ID: int = 0
-FM_EMISSIONS_ENTITY_ADDRESS: str = ""
 UTILITY_CONTEXT_DISPLAY_NAME: int = 0
 
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/fm_client.py
@@ -5,7 +5,6 @@ import asyncio
 import time
 import json
 import math
-import requests
 import constants as c
 from v2g_globals import time_round, get_local_now
 import appdaemon.plugins.hass.hassapi as hass
@@ -48,8 +47,7 @@ class FMClient(hass.Hass):
     # For sending notifications to the user.
     v2g_main_app: object
 
-    client: object
-    resolution: timedelta
+    client: object # Should be FlexMeasuresClient but (early) import statement gives errors..
 
     async def initialize(self):
         self.log("Initializing FlexMeasuresClient")
@@ -59,7 +57,6 @@ class FMClient(hass.Hass):
         self.fm_token = ""
         self.fm_busy_getting_schedule = False
         self.fm_date_time_last_schedule = get_local_now()
-        self.resolution = timedelta(minutes=c.FM_EVENT_RESOLUTION_IN_MINUTES)
 
         # Maybe add these to constants / settings?
         self.FM_SCHEDULE_DURATION_STR = "PT27H"
@@ -164,83 +161,99 @@ class FMClient(hass.Hass):
         #     self.log("No communication with FM! Increase tracking frequency.")
         #     await self.v2g_main_app.handle_no_new_schedule("no_communication_with_fm", True)
 
-    def authenticate_with_fm(self):
-        """Authenticate with the FlexMeasures server and store the returned auth token.
 
-        Hint:
-        the lifetime of the token is limited, so also call this method whenever the server returns a 401 status code.
+    async def get_sensor_data(self,
+        sensor_id: int,
+        start: str | datetime,
+        duration: str | timedelta,
+        uom: str,
+        resolution: str | timedelta
+    ) -> dict:
         """
-        # self.log(f"Authenticating with FlexMeasures on URL '{c.FM_AUTHENTICATION_URL}'.")
-        url = c.FM_AUTHENTICATION_URL
-        res = requests.post(
-            url,
-            json=dict(
-                email=c.FM_ACCOUNT_USERNAME,
-                password=c.FM_ACCOUNT_PASSWORD,
-            ),
-        )
-        now = get_local_now().strftime(c.DATE_TIME_FORMAT)
-        if not res.status_code == 200:
-            self.log_failed_response(res, url)
-            message = f"Failed to connect/login at {now}."
-            self.set_state("input_text.fm_connection_status", state=message)
-            return False
-        json_response = res.json()
-        if json_response is None:
-            self.log(f"Authenticating failed, no valid json response.")
+        :param sensor_id: fm sensor id
+        :param start:
+        :param duration:
+        :param uom: unit of measurement
+        :param resolution:
+        :return: sensor data as dictionary, for example:
+                {
+                    'values': [2.15, 3, 2],
+                    'start': '2015-06-02T10:00:00+00:00',
+                    'duration': 'PT45M',
+                    'unit': 'MW'
+                }
+        """
+        self.log(f"get_sensor_data called for sensor_id: {sensor_id}.")
+        try:
+            res = await self.client.get_sensor_data(
+                sensor_id = sensor_id,
+                start = start,
+                duration = duration,
+                unit =  uom,
+                resolution = resolution
+            )
+        except Exception as e:
+            # ContentTypeError, ValueError, timeout, no data??:
+            self.log(f"get_sensor_data for sensor_id: '{sensor_id}', start: '{start}', duration: '{duration}', "
+                     f"unit: '{uom}',  resolution: '{resolution}' failed, client returned exception: '{e}'.")
+            return None
+
+        return res
+
+    async def post_measurements(self,
+        sensor_id: int,
+        values: list[float],
+        start: datetime,
+        duration: str,
+        uom: str
+    ) -> bool:
+        """ General function to post data to FM.
+
+        Args:
+            sensor_id (str): FM sensor id that the measurements get posted to
+            values (list): list of values to send
+            start (datetime): start date-time of first value
+            duration (str): duration for which the values are relevant in iso format e.g. PT8H45M
+            uom (str): unit of measure, eg MW, EUR/kWh, etc.
+
+        Returns:
+            bool: weather or not sending was successful
+        """
+        self.log(f"post_measurements called.")
+        if len(values) == 0:
+            self.log(f"post_measurements, value list 0 length, not sending data to sensor_id '{sensor_id}'.")
             return False
 
-        self.fm_token = json_response.get("auth_token", None)
-        if self.fm_token is None:
-            self.log(f"Authenticating failed, no auth_token in json response: '{json_response}'.")
+        try:
+            await self.client.post_measurements(
+                sensor_id = sensor_id,
+                values = values,
+                start = start,
+                duration = duration,
+                unit = uom,
+            )
+        except Exception as e:
+            # ContentTypeError, ValueError, timeout??:
+            self.log(f"post_measurements failed | sensor_id: '{sensor_id}', values: '{values}', start: '{start}', "
+                     f"duration: '{duration}', unit: '{uom}', fm_client returned exception: '{e}'.")
             return False
-        message = f"Successful connect+login"
-        self.set_state("input_text.fm_connection_status", state=message)
+
         return True
 
-    def log_failed_response(self, res, endpoint: str):
-        """Log failed response for a given endpoint."""
-        try:
-            tmp= str(res.json())
-            if len(tmp) > 500:
-                tmp = f"{tmp[0:350]}.....{tmp[-150:]}"
-            self.log(f'{endpoint} failed ({res.status_code}) with JSON response "{tmp}"')
-        except json.decoder.JSONDecodeError:
-            self.log(f"{endpoint} failed ({tmp.status_code}) with response {tmp}")
-
-    def check_deprecation_and_sunset(self, url, res):
-        """Log deprecation and sunset headers, along with info links.
-
-        Reference
-        ---------
-        https://flexmeasures.readthedocs.io/en/latest/api/introduction.html#deprecation-and-sunset
-        """
-        warnings = res.headers.get("Deprecation") or res.headers.get("Sunset")
-        if warnings:
-            message = f"Your request to {url} returned a warning."
-            # Go through the response headers in their given order
-            for header, content in res.headers.items():
-                if header == "Deprecation":
-                    message += f"\nDeprecation: {content}."
-                elif header == "Sunset":
-                    message += f"\nSunset: {content}."
-                elif header == "Link" and ('rel="deprecation";' in content or 'rel="sunset";' in content):
-                    message += f" Link for further info: {content}"
-            self.log(message)
 
     async def get_new_schedule(self, targets: list, current_soc_kwh: float, back_to_max_soc: datetime):
-        """Get a new schedule from FlexMeasures.
-           But not if still busy with getting previous schedule.
-        Trigger a new schedule to be computed and set a timer to retrieve it, by its schedule id.
-        Params:
-        targets: a list of targets (=dict with start, end, soc)
-        back_to_max_soc: if current SoC > Max_SoC this setting informs the schedule when to be back at max soc.
-        Can be None.
+        """ Get a new schedule from FlexMeasures.
+            But not if still busy with getting previous schedule.
+            Trigger a new schedule to be computed and set a timer to retrieve it, by its schedule id.
+            Params:
+            targets: a list of targets (=dict with start, end, soc)
+            back_to_max_soc: if current SoC > Max_SoC this setting informs the schedule when to be back at max soc.
+            Can be None.
         """
         self.log(f"get_new_schedule called.")
         now = get_local_now()
         if self.fm_busy_getting_schedule:
-            self.log(f"get_new_schedule self.fm_date_time_last_schedule {self.fm_date_time_last_schedule.isoformat()}.")
+            self.log(f"get_new_schedule, busy with prior request since: {self.fm_date_time_last_schedule.isoformat()}.")
             seconds_since_last_schedule = int((now - self.fm_date_time_last_schedule).total_seconds())
             if seconds_since_last_schedule > self.fm_max_seconds_between_schedules:
                 self.log(f"Retrieving previous schedule is taking too long ({seconds_since_last_schedule} sec.),"
@@ -255,39 +268,10 @@ class FMClient(hass.Hass):
         # and during this delay this get_new_schedule could be called.
         self.fm_busy_getting_schedule = True
 
-        # Ask to compute a new schedule by posting flex constraints while triggering the scheduler
-        schedule_id = await self.trigger_schedule(
-            targets = targets,
-            current_soc_kwh = current_soc_kwh,
-            back_to_max_soc = back_to_max_soc
-        )
-        if schedule_id is None:
-            self.log("Failed to trigger new schedule, schedule ID is None. Cannot call get_schedule")
-            self.fm_busy_getting_schedule = False
-            return
-
-        # Set a timer to get the schedule a little later
-        self.log(f"Attempting to get schedule (id={schedule_id}) in {self.DELAY_FOR_INITIAL_ATTEMPT} seconds")
-        self.run_in(self.get_schedule, delay=self.DELAY_FOR_INITIAL_ATTEMPT, schedule_id=schedule_id)
-
-
-    async def trigger_schedule(self, *args, **fnc_kwargs) -> str:
-        """Request a new schedule to be generated by calling the schedule triggering endpoint, while
-        POSTing flex constraints.
-        Return the schedule id for later retrieval of the asynchronously computed schedule.
-        """
-        current_soc_kwh = fnc_kwargs.get("current_soc_kwh", None)
-        if current_soc_kwh is None:
-            self.log(f"trigger_schedule: aborting as there is no current_soc_kwh.")
-            return
-
-        targets = fnc_kwargs.get("targets", None)
-        back_to_max_soc = fnc_kwargs.get("back_to_max_soc", None)
-        resolution = timedelta(minutes=c.FM_EVENT_RESOLUTION_IN_MINUTES)
-        rounded_now = time_round(get_local_now(), resolution)
+        rounded_now = time_round(now, c.EVENT_RESOLUTION)
 
         # The schedule duration, usually just over a day long.
-        schedule_end = time_round(rounded_now + self.FM_SCHEDULE_DURATION, resolution)
+        schedule_end = time_round(rounded_now + self.FM_SCHEDULE_DURATION, c.EVENT_RESOLUTION)
 
         # Add a placeholder target with soc CAR_MAX_SOC_IN_KWH (usually ≈80%) one week from now.
         # FM needs this to be able to produce a schedule whereby the influence of this placeholder is none.
@@ -312,7 +296,7 @@ class FMClient(hass.Hass):
             ##################################
             #    Make a list of soc_minima   #
             ##################################
-            self.log(f"Trigger_schedule. start generating soc_minima'.")
+            self.log(f"get_new_schedule, start generating soc_minima'.")
             for target in targets:
                 target_start = target["start"]
                 target_end = target["end"]
@@ -332,14 +316,16 @@ class FMClient(hass.Hass):
                 #     "start": target_start,
                 #     "end": target_end,
                 # })
+            # -- End for target in targets --
+
             # Always add a future target for scheduling to be made possible.
             soc_minima.append({
                 'value': c.CAR_MAX_SOC_IN_KWH,
-                'start': end_of_schedule_input_period - self.resolution,
+                'start': end_of_schedule_input_period - c.EVENT_RESOLUTION,
                 'end': end_of_schedule_input_period,
             })
             # Remove any overlap and use the maximum in overlapping periods.
-            soc_minima = self.consolidate_time_ranges(soc_minima)
+            soc_minima = consolidate_time_ranges(soc_minima)
 
             # TODO: soc_usage
             # soc_usage = self.consolidate_time_ranges(soc_usage)
@@ -348,7 +334,7 @@ class FMClient(hass.Hass):
             ##################################
             #   Make a list of soc_maxima    #
             ##################################
-            self.log(f"Trigger_schedule. start generating soc_maxima'.")
+            self.log(f"get_new_schedule, start generating soc_maxima'.")
 
             # The basis maxima that can be lifted by adding other maxima
             soc_maxima = [{
@@ -369,27 +355,30 @@ class FMClient(hass.Hass):
                 if minimum_soc_kwh > c.CAR_MAX_SOC_IN_KWH:
                     window_duration = math.ceil((minimum_soc_kwh - c.CAR_MAX_SOC_IN_KWH) /
                                       (c.CHARGER_MAX_CHARGE_POWER / 1000) * 60) + self.WINDOW_SLACK_IN_MINUTES
-                    self.log(f"trigger_schedule window_duration: {window_duration}.")
+                    self.log(f"get_new_schedule window_duration: {window_duration}.")
                     # srw = start_relaxation_window, erw = end_relaxation_window
-                    srw = time_round((soc_minimum_start - timedelta(minutes=window_duration)), resolution)
-                    erw = time_round((soc_minimum_end + timedelta(minutes=window_duration)), resolution)
+                    srw = time_round((soc_minimum_start - timedelta(minutes=window_duration)), c.EVENT_RESOLUTION)
+                    erw = time_round((soc_minimum_end + timedelta(minutes=window_duration)), c.EVENT_RESOLUTION)
                     if srw < rounded_now:
                         # This is when the target SoC cannot be reached at the calendar-item_start, Scenario 3.
                         srw = rounded_now
                         # In this case it is never relevant to go back to max_soc
                         back_to_max_soc = None
-                        self.log("Strategy for soc_maxima: Priority for calendar target (Scenario 3).")
+                        self.log("get_new_schedule, strategy for soc_maxima: "
+                                 "Priority for calendar target (Scenario 3).")
                     if srw < first_b2ms_reset_moment:
                         first_b2ms_reset_moment = srw
-                    self.log(f"trigger_schedule srw: {srw}.")
+                    self.log(f"get_new_schedule srw: {srw}.")
 
                     soc_maxima.append({
                         "value": minimum_soc_kwh,
                         "start": srw,
                         "end": erw,
                     })
-                self.log(f"Soc_minima processed, first_b2ms_reset_moment: {first_b2ms_reset_moment.isoformat()}.")
-
+                self.log(f"get_new_schedule, soc_minima processed - "
+                         f"first_b2ms_reset_moment: {first_b2ms_reset_moment.isoformat()}.")
+            # -- End for soc_minimum in soc_minima --
+        # -- End if targets not None --
 
         # Range where schedule should only discharge. This when the SoC is above the max (80%).
         # This can be due to returning home and connection with a high SoC or when the car did not
@@ -432,7 +421,7 @@ class FMClient(hass.Hass):
 
         b2ms_maxima = []
         if back_to_max_soc is not None and isinstance(back_to_max_soc, datetime):
-            self.log(f"trigger_schedule, back_to_max_soc: '{back_to_max_soc}'.")
+            self.log(f"get_new_schedule, back_to_max_soc: '{back_to_max_soc}'.")
 
             # Postpone discharge till after current calendar item if target soc has not been fulfilled
             start_b2ms = None
@@ -451,7 +440,7 @@ class FMClient(hass.Hass):
             minimum_discharge_window = math.ceil(
                 (current_soc_kwh - c.CAR_MAX_SOC_IN_KWH) / (c.CHARGER_MAX_DISCHARGE_POWER / 1000) * 60)
             end_minimum_discharge_window = time_round((start_b2ms - timedelta(minutes=minimum_discharge_window)),
-                                                      resolution)
+                                                      c.EVENT_RESOLUTION)
             if end_minimum_discharge_window > back_to_max_soc:
                 # Scenario A.
                 back_to_max_soc = end_minimum_discharge_window
@@ -463,7 +452,8 @@ class FMClient(hass.Hass):
                     "start": rounded_now,
                     "end": first_b2ms_reset_moment,
                 })
-                self.log("Strategy for soc_maxima: Maxima current_soc until Start of relaxation window (Scenario 2).")
+                self.log("get_new_schedule, strategy for soc_maxima: "
+                         "Maxima current_soc until Start of relaxation window (Scenario 2).")
             else:
                 # Scenario 1: Gradually decrease SoC to reach c.CAR_MAX_SOC_IN_KWH by means of setting soc_maxima
                 # TODO: A drawback of the gradual approach is that there might be discharging with low power which
@@ -472,29 +462,29 @@ class FMClient(hass.Hass):
                 #       This should then replace the gradually lowered soc_maxima.
                 #       Use target = c.CAR_MAX_SOC_IN_KWH at back_to_max_soc in combination with dynamic power
                 #       constraint, production_power=0. See https://github.com/V2G-liberty/addon-v2g-liberty/issues/41.
-                number_of_steps = (back_to_max_soc - rounded_now) // resolution
+                number_of_steps = (back_to_max_soc - rounded_now) // c.EVENT_RESOLUTION
                 if number_of_steps > 0:
                     step_kwh = (current_soc_kwh - c.CAR_MAX_SOC_IN_KWH) / number_of_steps
                     for i in range(number_of_steps):
                         b2ms_maxima.append({
                             "value": current_soc_kwh - (i * step_kwh),
-                            "datetime": (rounded_now + i * resolution).isoformat()
+                            "datetime": (rounded_now + i * c.EVENT_RESOLUTION).isoformat()
                         })
-                self.log(f"Strategy for soc_maxima: Gradually decrease SoC to "
+                self.log(f"get_new_schedule, strategy for soc_maxima: Gradually decrease SoC to "
                          f"reach {c.CAR_MAX_SOC_IN_KWH}kWh (Scenario 1).")
+        # -- End if back_to_max_soc is not None and isinstance(back_to_max_soc, datetime) --
 
-        soc_maxima = self.consolidate_time_ranges(soc_maxima)
+        soc_maxima = consolidate_time_ranges(soc_maxima)
         soc_maxima = convert_dates_to_iso_format(soc_maxima)
         soc_maxima += b2ms_maxima
 
         soc_minima = convert_dates_to_iso_format(soc_minima)
 
-        # TODO: Add "soc-usage"
+        # TODO: convert soc_usage
         # soc_usage = convert_dates_to_iso_format(soc_usage)
 
-        message = {
-            "start": rounded_now.isoformat(),
-            "flex-model": {
+        # TODO: Add "soc-usage"
+        flex_model = {
                 "soc-at-start": current_soc_kwh,
                 "soc-unit": "kWh",
                 "soc-min": c.CAR_MIN_SOC_IN_KWH,
@@ -503,180 +493,49 @@ class FMClient(hass.Hass):
                 "soc-maxima": soc_maxima,
                 "roundtrip-efficiency": c.ROUNDTRIP_EFFICIENCY_FACTOR,
                 "power-capacity": str(c.CHARGER_MAX_CHARGE_POWER) + "W"
-            },
-            "flex-context": c.FM_OPTIMISATION_CONTEXT,
-        }
-
-        url = c.FM_TRIGGER_URL
-        tmp = str(message)
-        self.log(f"Trigger_schedule with message: '{tmp}'.")
-        # self.log(f"Trigger_schedule on url '{url}', with message: '{tmp[0:300]} . . . . . {tmp[-250:]}'.")
-        res = requests.post(
-            url,
-            json=message,
-            headers={"Authorization": self.fm_token},
-        )
-
-        self.check_deprecation_and_sunset(url, res)
-
-        if res.status_code == 401:
-            self.log_failed_response(res, url)
-            await self.try_solve_authentication_error(res, url, self.trigger_schedule, *args, **fnc_kwargs)
-            return None
-
-        schedule_id = None
-        if res.status_code == 200:
-            schedule_id = res.json()["schedule"]  # can still be None in case something went wong
-
-        if schedule_id is None:
-            self.log_failed_response(res, url)
+            }
+        self.log(f"get_new_schedule | flex_model: {flex_model}.")
+        schedule = {}
+        try:
+            schedule = await self.client.trigger_and_get_schedule(
+                sensor_id = c.FM_ACCOUNT_POWER_SENSOR_ID,
+                duration = self.FM_SCHEDULE_DURATION_STR,
+                start = rounded_now.isoformat(),
+                flex_model = flex_model,
+                flex_context = c.FM_OPTIMISATION_CONTEXT,
+            )
+        except Exception as e:
+            # ContentTypeError, ValueError, timeout??:
+            self.log(f"get_new_schedule, failed to get schedule, client returned exception: {e}.")
+            self.fm_busy_getting_schedule = False
             if self.v2g_main_app is not None:
                 await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", True)
             else:
-                self.log(f"get_schedule. Could not call v2g_main_app.handle_no_new_schedule (3). Exception: {e}.")
+                self.log(f"get_new_schedule. "
+                         f"Could not call handle_no_new_schedule on v2g_main_app as it is None.")
+            return
 
-            return None
-
-        self.log(f"Successfully triggered schedule. Schedule id: {schedule_id}")
-        if self.v2g_main_app is not None:
-            await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", False)
-        else:
-            self.log(f"get_schedule. Could not call handle_no_new_schedule (4) on v2g_main_app as it is None.")
-
-        return schedule_id
-
-
-    def consolidate_time_ranges(self, ranges):
-        """ Processes a list of time-value ranges, merging overlapping intervals """
-        if len(ranges) == 0:
-            self.log("consolidate_time_ranges, ranges = [], aborting")
-            return []
-        elif len(ranges) == 1:
-            self.log("consolidate_time_ranges, only one range so nothing to consolidate, returning ranges untouched.")
-            return ranges
-        time_slots = self.generate_time_slots(ranges)
-        combined_ranges = self.combine_time_slots(time_slots)
-        return combined_ranges
-
-    def generate_time_slots(self, ranges):
-        """Generates a dictionary of time_slots at resolution with the maximum value for each time_slot."""
-        time_slots = {}
-        for time_range in ranges:
-            current_time = time_range['start']
-            end_time = time_range['end']
-            while current_time <= end_time:
-                if current_time not in time_slots:
-                    time_slots[current_time] = time_range['value']
-                else:
-                    time_slots[current_time] = max(time_slots[current_time], time_range['value'])
-                current_time += self.resolution
-        return time_slots
-
-    def combine_time_slots(self, time_slots):
-        """Merges time slots into non-overlapping intervals with the same value."""
-
-        combined_ranges = []
-        sorted_times = sorted(time_slots.keys())
-        current_start = sorted_times[0]
-        current_value = time_slots[current_start]
-
-        for i in range(1, len(sorted_times)):
-            current_time = sorted_times[i]
-            expected_time = sorted_times[i - 1] + self.resolution
-            # self.log(f"s: {current_start}, t: {current_time}, e: {expected_time}, c: {current_value}, v: {time_slots[current_time]}.")
-            if current_time != expected_time or time_slots[current_time] != current_value:
-                combined_ranges.append({
-                    'value': current_value,
-                    'start': current_start,
-                    'end': sorted_times[i - 1]
-                })
-                current_start = current_time
-                current_value = time_slots[current_time]
-
-        # Add the last range
-        combined_ranges.append({
-            'value': current_value,
-            'start': current_start,
-            'end': sorted_times[-1]
-        })
-        return combined_ranges
-
-    async def get_schedule(self, kwargs, **fnc_kwargs):
-        """GET a schedule message that has been requested by trigger_schedule.
-           The ID for this is schedule_id.
-           Then store the retrieved schedule.
-
-        Pass the schedule id using kwargs["schedule_id"]=<schedule_id>.
-        """
-        # Just to be sure also set this here, it's primary point for setting to true is in get_new_schedule
-        self.fm_busy_getting_schedule = True
-
-        schedule_id = kwargs["schedule_id"]
-        url = c.FM_GET_SCHEDULE_URL + schedule_id
-        message = {
-            "duration": self.FM_SCHEDULE_DURATION_STR,
-        }
-        res = requests.get(
-            url,
-            params=message,
-            headers={"Authorization": self.fm_token},
-        )
-        self.check_deprecation_and_sunset(url, res)
-        if res.status_code == 303:
-            new_url = res.headers.get("location")
-            if new_url is not None:
-                self.log(f"Redirecting from {url} to {new_url}")
-                url = new_url
-                res = requests.get(
-                    url,
-                    params=message,
-                    headers={"Authorization": self.fm_token},
-                )
-
-        if (res.status_code != 200) or (res.json is None):
-            self.log_failed_response(res, url)
-            s = self.DELAY_FOR_REATTEMPTS
-            attempts_left = kwargs.get("attempts_left", self.MAX_NUMBER_OF_REATTEMPTS)
-            if attempts_left >= 1:
-                self.log(f"Reattempting to get schedule in {s} seconds (attempts left: {attempts_left})")
-                self.run_in(self.get_schedule, delay=s, attempts_left=attempts_left - 1,
-                            schedule_id=schedule_id)
-            else:
-                self.log("Schedule cannot be retrieved. Any previous charging schedule will keep being followed.")
-                self.fm_busy_getting_schedule = False
-
-                if self.v2g_main_app is not None:
-                    await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", True)
-                else:
-                    self.log(f"get_schedule. Could not call handle_no_new_schedule (1) on v2g_main_app as it is None.")
-
-            return False
-        # self.log(f"get_schedule. successfully retrieved {res.status_code}")
         self.fm_busy_getting_schedule = False
-        if self.v2g_main_app is not None:
-            await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", False)
-        else:
-            self.log(f"get_schedule. Could not call handle_no_new_schedule (2) on v2g_main_app as it is None.")
 
+        if schedule == {}:
+            self.log(f"get_new_schedule, schedule is empty")
+            if self.v2g_main_app is not None:
+                await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", True)
+            else:
+                self.log(f"get_new_schedule. "
+                         f"Could not call handle_no_new_schedule on v2g_main_app as it is None.")
+            return
+
+        await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", False)
         self.fm_date_time_last_schedule = get_local_now()
-        self.log(f"get_schedule: self.fm_date_time_last_schedule set to now,"
-                 f" {self.fm_date_time_last_schedule.isoformat()}, ({type(self.fm_date_time_last_schedule)}).")
+        self.log(f"get_new_schedule, schedule: {schedule}")
 
-        schedule = res.json()
-        self.log(f"Schedule {schedule}")
         # To trigger state change we add the date to the state. State change is not triggered by attributes.
-        self.set_state("input_text.chargeschedule",
-                       state="ChargeScheduleAvailable" + self.fm_date_time_last_schedule.isoformat(),
-                       attributes=schedule)
-
-
-    async def try_solve_authentication_error(self, res, url, fnc, *fnc_args, **fnc_kwargs):
-        if fnc_kwargs.get("retry_auth_once", True) and res.status_code == 401:
-            self.log(f"Call to {url} failed on authorization (possibly the token expired); attempting to "
-                     f"reauthenticate once.")
-            self.authenticate_with_fm()
-            fnc_kwargs["retry_auth_once"] = False
-            await fnc(*fnc_args, **fnc_kwargs)
+        self.set_state(
+            entity_id = "input_text.chargeschedule",
+            state = "ChargeScheduleAvailable" + self.fm_date_time_last_schedule.isoformat(),
+            attributes = schedule
+        )
 
 
 def get_host_and_ssl_from_url(url: str) -> tuple[str, bool]:
@@ -695,7 +554,66 @@ def get_host_and_ssl_from_url(url: str) -> tuple[str, bool]:
     return host, ssl
 
 
+def combine_time_slots(time_slots):
+    """Merges time slots into non-overlapping intervals with the same value."""
+
+    combined_ranges = []
+    sorted_times = sorted(time_slots.keys())
+    current_start = sorted_times[0]
+    current_value = time_slots[current_start]
+
+    for i in range(1, len(sorted_times)):
+        current_time = sorted_times[i]
+        expected_time = sorted_times[i - 1] + c.EVENT_RESOLUTION
+        # self.log(f"s: {current_start}, t: {current_time}, e: {expected_time}, c: {current_value}, v: {time_slots[current_time]}.")
+        if current_time != expected_time or time_slots[current_time] != current_value:
+            combined_ranges.append({
+                'value': current_value,
+                'start': current_start,
+                'end': sorted_times[i - 1]
+            })
+            current_start = current_time
+            current_value = time_slots[current_time]
+
+    # Add the last range
+    combined_ranges.append({
+        'value': current_value,
+        'start': current_start,
+        'end': sorted_times[-1]
+    })
+    return combined_ranges
+
+
+def generate_time_slots(ranges):
+    """Generates a dictionary of time_slots at resolution with the maximum value for each time_slot."""
+    time_slots = {}
+    for time_range in ranges:
+        current_time = time_range['start']
+        end_time = time_range['end']
+        while current_time <= end_time:
+            if current_time not in time_slots:
+                time_slots[current_time] = time_range['value']
+            else:
+                time_slots[current_time] = max(time_slots[current_time], time_range['value'])
+            current_time += c.EVENT_RESOLUTION
+    return time_slots
+
+
+def consolidate_time_ranges(ranges):
+    """ Processes a list of time-value ranges, merging overlapping intervals """
+    if len(ranges) == 0:
+        # self.log("consolidate_time_ranges, ranges = [], aborting")
+        return []
+    elif len(ranges) == 1:
+        # self.log("consolidate_time_ranges, only one range so nothing to consolidate, returning ranges untouched.")
+        return ranges
+    time_slots = generate_time_slots(ranges)
+    combined_ranges = combine_time_slots(time_slots)
+    return combined_ranges
+
 def get_keepalive():
+    """ Generate a unique string to be used in setting entity states. So, even when the
+    attributes remain the same, it will be treated as a new value and trigger a change event."""
     now = get_local_now().strftime(c.DATE_TIME_FORMAT)
     return {"keep_alive": now}
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/modbus_evse_client.py
@@ -381,7 +381,7 @@ class ModbusEVSEclient(hass.Hass):
             return False
 
         # The method self.__get_charger_state() cannot be used as it is async and this
-        # method should not be as it is called from sync code (set_fm_data.py).
+        # method should not be as it is called from sync code (data_monitor.py).
         return self.ENTITY_CHARGER_STATE['current_value'] in self.AVAILABILITY_STATES
 
 


### PR DESCRIPTION
- Use flexmeasures_client python library for all calls to FM This makes getting schedules and other data (much) faster.
- Renamed set_fm_data to data_monitor, this reflects its function better.
- Made one global constant for RESOLUTION.
- Renamed variable that holds the reference to the fm_client module (currently named fm_client) to fm_client_app to prevent confusion.