### PR TITLE
#100 🪲 BUG: Error message for "Charger is controlled by app" not showing

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/modbus_evse_client.py
@@ -212,7 +212,7 @@ class ModbusEVSEclient(hass.Hass):
         0: 'No car connected',
         1: 'Charging',
         2: 'Connected: waiting for car demand',
-        3: 'Connected: controlled by EVSE App',
+        3: 'Connected: controlled by Wallbox App',
         4: 'Connected: not charging (paused)',
         5: 'Connected: end of schedule',
         6: 'No car connected and charger locked',

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/v2g_liberty.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/v2g_liberty.py
@@ -108,7 +108,7 @@ class V2Gliberty(hass.Hass):
             "no_communication_with_fm": False
         }
         # Reset at init
-        self.turn_off("input_boolean.charger_modbus_communication_fault")
+        await self.turn_off("input_boolean.charger_modbus_communication_fault")
 
         self.notification_timer_handle = None
         self.no_schedule_notification_is_planned = False
@@ -117,13 +117,13 @@ class V2Gliberty(hass.Hass):
         self.fm_client_app = await self.get_app("fm_client")
         self.reservations_client = await self.get_app("reservations-client")
 
-        self.listen_state(self.__update_charge_mode, "input_select.charge_mode", attribute="all")
-        self.listen_event(self.__disconnect_charger, "DISCONNECT_CHARGER")
-        self.listen_event(self.__handle_phone_action, event="mobile_app_notification_action")
+        await self.listen_state(self.__update_charge_mode, "input_select.charge_mode", attribute="all")
+        await self.listen_event(self.__disconnect_charger, "DISCONNECT_CHARGER")
+        await self.listen_event(self.__handle_phone_action, event="mobile_app_notification_action")
 
-        self.listen_state(self.__handle_charger_state_change, "sensor.charger_charger_state", attribute="all")
-        self.listen_state(self.__handle_soc_change, "sensor.charger_connected_car_state_of_charge", attribute="all")
-        self.listen_state(self.__process_schedule, "input_text.chargeschedule", attribute="all")
+        await self.listen_state(self.__handle_charger_state_change, "sensor.charger_charger_state", attribute="all")
+        await self.listen_state(self.__handle_soc_change, "sensor.charger_connected_car_state_of_charge", attribute="all")
+        await self.listen_state(self.__process_schedule, "input_text.chargeschedule", attribute="all")
 
         self.scheduling_timer_handles = []
 
@@ -161,8 +161,8 @@ class V2Gliberty(hass.Hass):
 
     async def initialise_v2g_liberty(self, v2g_args=None):
         # Show the settings in the UI
-        self.set_textvalue("input_text.optimisation_mode", c.OPTIMISATION_MODE)
-        self.set_textvalue("input_text.utility_display_name", c.UTILITY_CONTEXT_DISPLAY_NAME)
+        await self.set_textvalue("input_text.optimisation_mode", c.OPTIMISATION_MODE)
+        await self.set_textvalue("input_text.utility_display_name", c.UTILITY_CONTEXT_DISPLAY_NAME)
         await self.set_next_action(v2g_args=v2g_args)  # on initializing the app
 
 
@@ -910,11 +910,11 @@ class V2Gliberty(hass.Hass):
 
         # Cleaned_up SoC value for UI
         # TODO: This is no longer needed, use input_number.charger_connected_car_state_of_charge in UI.
-        self.set_value("input_number.car_state_of_charge", self.connected_car_soc)
+        await self.set_value(entity_id="input_number.car_state_of_charge", value=self.connected_car_soc)
 
         self.connected_car_soc_kwh = round(reported_soc * float(c.CAR_MAX_CAPACITY_IN_KWH / 100), 2)
         remaining_range = int(round((self.connected_car_soc_kwh * 1000 / c.CAR_CONSUMPTION_WH_PER_KM), 0))
-        self.set_value("input_number.car_remaining_range", remaining_range)
+        await self.set_value(entity_id="input_number.car_remaining_range", value=remaining_range)
         self.log(f"New SoC processed, self.connected_car_soc is now set to: {self.connected_car_soc}%.")
         self.log(f"New SoC processed, self.connected_car_soc_kwh is now set to: {self.connected_car_soc_kwh}kWh.")
         self.log(f"New SoC processed, car_remaining_range is now set to: {remaining_range} km.")
@@ -1130,7 +1130,7 @@ class V2Gliberty(hass.Hass):
         By setting the UI switch an event will also be fired. So other code will run due to this setting.
 
         Parameters:
-        setting (str): Automatic, MaxBoostNow or Stop (=Off))
+        setting (str): Automatic, MaxBoostNow or Stop (=Off)
 
         Returns:
         nothing.

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_dashboard.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_dashboard.yaml
@@ -179,7 +179,7 @@ views:
             min: 0
             max: 100
             name: Car SoC
-            # TODO: Base these values on user settings min/max charge (in secrets).
+            # TODO: Base these values on user settings min/max charge settings.
             segments:
               - from: 0
                 color: var(--error-color)


### PR DESCRIPTION
- Changed the name of the state 3 to "Connected: controlled by Wallbox App"
- Did some cleanup in v2g_liberty module
- did some cleanup in dashboard