### PR TITLE
 FeatureRequest 🛠️: Change charge mode "Off" to "Pause" and keep poling charger (#102)

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/modbus_evse_client.py
@@ -353,7 +353,7 @@ class ModbusEVSEclient(hass.Hass):
         """To be called when charge_mode in UI is (switched to) Stop"""
         self.log("evse: set_inactive called")
         await self.stop_charging()
-        await self.__cancel_polling(reason="Set inactive called")
+        # await self.__cancel_polling(reason="Set inactive called")
         await self.__set_charger_control("give")
         self._am_i_active = False
 
@@ -873,8 +873,8 @@ class ModbusEVSEclient(hass.Hass):
     ######################################################################
 
     async def __update_poll_indicator_in_ui(self, reset: bool = False):
-        # This can be shown directly as text in the UI (or use ⏲ ⟳ 🔃 🔄?) but,
-        # as the "last_changed" attribute also changes, an "age" could be shown based on this as well
+        # Toggles the char in the UI to indicate polling activity,
+        # as the "last_changed" attribute also changes, an "age" could be shown based on this as well.
         self.poll_update_text = "↺" if self.poll_update_text != "↺" else "↻"
         if reset:
             self.poll_update_text = ""
@@ -1190,6 +1190,7 @@ class ModbusEVSEclient(hass.Hass):
         await self.__cancel_polling(reason="un_recoverable modbus error")
         # The only exception to the rule that _am_i_active should only be set from "set_(in)active()"
         self._am_i_active = False
+        await self.__cancel_polling()
         await self.v2g_main_app.notify_user_of_charger_needs_restart(
             was_car_connected=await self.is_car_connected()
         )

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_dashboard.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_dashboard.yaml
@@ -535,7 +535,8 @@ views:
                       padding: 10% 0 !important;
                     }
               - type: button
-                name: "Off"
+                name: "Pause"
+                icon: mdi:pause-box-outline
                 hold_action:
                   action: none
                 entity: input_boolean.chargemodeoff
@@ -543,10 +544,31 @@ views:
                 show_state: false
                 card_mod:
                   style: |
+                    # Overflow is needed as otherwise the popup is cut-off outside of the button (and then useless).
+                    :host * {
+                      overflow: visible !important;
+                    }
                     ha-card {
                       padding: 10% 0 !important;
                     }
+                    ha-card:hover::before {
+                      content: "Pause scheduled charging and give control to the charger. \A Want to stop V2G Liberty completely? Use the link on the settings tab in the top bar.";
+                      text-align: left;
+                      white-space: pre-wrap;
+                      font-size: 80%;
+                      color: var(--primary-text-color);
+                      position: absolute !important;
+                      width: 240px;
+                      right: 12px;
+                      top: 96px;
+                      background-color: var(--primary-background-color);
+                      border: 1px solid var(--input-idle-line-color);
+                      border-radius: 8px;
+                      padding: 8px 16px;
+                      z-index: 110;
+                    }
             square: false
+
           - type: conditional
             conditions:
               - entity: input_text.charger_state
@@ -1351,7 +1373,7 @@ views:
             entities:
               - type: button
                 name: ' '
-                action_name: ↺ Restart V2G Liberty
+                action_name: 🔄 Restart V2G Liberty ››
                 tap_action:
                   action: call-service
                   confirmation:
@@ -1360,7 +1382,16 @@ views:
                   target: {}
               - type: button
                 name: ' '
-                action_name: Reset to factory defaults >>
+                action_name: 🛑 Stop V2G Liberty ››
+                tap_action:
+                  action: call-service
+                  confirmation:
+                    text: The only way to stop V2G Liberty is to stop the add-on. Goto Settings -> Add-ons -> V2G Liberty -> Stop
+                  service: script.stop_v2g_liberty
+                  target: {}
+              - type: button
+                name: ' '
+                action_name: 🏭 Reset to factory defaults ››
                 tap_action:
                   action: call-service
                   confirmation:


### PR DESCRIPTION
- Pause now does not stop polling. When a crash of the charger modbus module is detected the polling is stopped.
- Changed the button icon and added a tooltip to explain how to stop V2G Liberty.
- Added icons to the Restart /Stop / Reset links on settings page for clarity.