### PR TITLE
#41 Do not (dis-)charge during calendar item

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 0.4.0 2024-10-30
+
+### Added
+
+-  Do not (dis-)charge during calendar item (#41)
+
+### Removed
+
+- Template sensor for timezone, old unused code (unnumbered).
+
+
+
+## [Unreleased]
+
+The next release **might (!)** include:
+
+### Adding
+
+- Support for uni-directional charging
+
+### Changing
+
+- New frontend for the settings page
+
+### Removing
+
+- ?
+
+
+## Complete changelog of all releases
+
+To keep things readable here a separate document is maintained 
+with [the complete list of all changes for all past releases](changelog_of_all_releases.md).
+
+&nbsp;

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -1,20 +1,14 @@
-# Changelog
+# Changelog of all releases
 
-## [Unreleased]
+A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
+That file also contains possible changes that the next release might include.
 
-The next release might include:
+## 0.3.3 2024-10-17
 
-### Adding
+### Fixed
 
-- Support for uni-directional charging
+-  🪲 BUG: admin_mobile name select is changing several times per second #124 
 
-### Changing
-
--  Do not (dis-)charge during calendar item (#41)
-
-### Removing
-
-- ?
 
 
 ## 0.3.2 2024-10-16

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g-liberty/v2g_globals.py
@@ -173,7 +173,9 @@ class V2GLibertyGlobals(ServiceResponseApp):
         "entity_name": "allowed_duration_above_max_soc_in_hrs",
         "entity_type": "input_number",
         "value_type": "int",
-        "factory_default": 12,
+        "factory_default": 4,
+        "min": 1,
+        "max": 12,
         "listener_id": None
     }
     SETTING_USE_REDUCED_MAX_CHARGE_POWER = {
@@ -326,7 +328,6 @@ class V2GLibertyGlobals(ServiceResponseApp):
         # Was None, which blocks processing during initialisation
         self.collect_action_handle = ""
         self.log("Completed initializing V2GLibertyGlobals")
-
 
 
     ######################################################################

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
@@ -238,8 +238,8 @@ input_number:
 
   allowed_duration_above_max_soc_in_hrs:
     name: Allowed duration above max soc
-    min: 2
-    max: 36
+    min: 1
+    max: 12
     step: 1
     icon: mdi:timer-lock-outline
     mode: box
@@ -518,12 +518,6 @@ input_text:
     min: 0
     mode: text
 
-template:
-  - sensor:
-    # To make the HA time_zone available to the V2G Liberty python code.
-    - name: Time Zone
-      unique_id: time_zone
-      state: "{{ now().tzinfo }}"
 
 script:
   restart_ha:

--- a/v2g-liberty/rootfs/root/tests/test_fm_client_generate_time_slots.py
+++ b/v2g-liberty/rootfs/root/tests/test_fm_client_generate_time_slots.py
@@ -1,0 +1,193 @@
+
+####################################### README #######################################
+#                                                                                    #
+#  This is a separate unit test for __generate_time_slots().                         #
+#  The function is an exact copy of the one in test_fm_client-ranges_integral.py,    #
+#  and as such this test forms a fundament for the integral test.                    #
+#                                                                                    #
+######################################################################################
+
+from datetime import datetime, timedelta
+
+c = type('c', (), {'EVENT_RESOLUTION': timedelta(minutes=5)})
+DTF = "%H:%M:%S"
+
+
+class TestGenerateTimeSlots():
+    def __init__(self):
+        self.test_generate_time_slots()
+
+    def test_generate_time_slots(self):
+        test_cases = [
+            {
+                "description": "Single range",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                ],
+                "expected": {
+                    '00:00:00': [5, 5],
+                    '00:05:00': [5, 5],
+                    '00:10:00': [5, 5],
+                }
+            },
+            {
+                "description": "Non-overlapping ranges with one-resolution distance",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:05:00", 'value': 10},
+                    {'start': "00:10:00", 'end': "00:15:00", 'value': 5},
+                    {'start': "00:25:00", 'end': "00:35:00", 'value': 15},
+                ],
+                "expected": {
+                    '00:00:00': [10, 10],
+                    '00:05:00': [10, 10],
+                    '00:10:00': [5, 5],
+                    '00:15:00': [5, 5],
+                    '00:25:00': [15, 15],
+                    '00:30:00': [15, 15],
+                    '00:35:00': [15, 15],
+                }
+            },
+            {
+                "description": "Touching ranges with max value",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 10},
+                    {'start': "00:10:00", 'end': "00:20:00", 'value': 15},
+                ],
+                "expected": {
+                    '00:00:00': [10, 10],
+                    '00:05:00': [10, 10],
+                    '00:10:00': [10, 15],
+                    '00:15:00': [15, 15],
+                    '00:20:00': [15, 15],
+                }
+            },
+            {
+                "description": "Overlapping ranges with min value",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                    {'start': "00:05:00", 'end': "00:15:00", 'value': 3},
+                ],
+                "expected": {
+                    '00:00:00': [5, 5],
+                    '00:05:00': [3, 5],
+                    '00:10:00': [3, 5],
+                    '00:15:00': [3, 3],
+                }
+            },
+            {
+                "description": "Contained ranges",
+                "input": [
+                    {'start': "00:10:00", 'end': "00:20:00", 'value': 15},  # Contained
+                    {'start': "00:15:00", 'end': "00:30:00", 'value': 25},  # Contained
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},  # Contained
+                    {'start': "00:00:00", 'end': "01:00:00", 'value': 35},  # Container
+                ],
+                "expected": {
+                    '00:00:00': [35, 35],
+                    '00:05:00': [35, 35],
+                    '00:10:00': [15, 35],
+                    '00:15:00': [15, 35],
+                    '00:20:00': [15, 35],
+                    '00:25:00': [25, 35],
+                    '00:30:00': [25, 35],
+                    '00:35:00': [35, 35],
+                    '00:40:00': [20, 35],
+                    '00:45:00': [20, 35],
+                    '00:50:00': [20, 35],
+                    '00:55:00': [35, 35],
+                    '01:00:00': [35, 35],
+                }
+            },
+            {
+                "description": "Contained with varying min and max",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 0},  # Contained
+                    {'start': "00:10:00", 'end': "00:20:00", 'value': 15},  # Contained
+                    {'start': "00:15:00", 'end': "00:30:00", 'value': 25},  # Contained
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},  # Contained
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 0},  # Contained
+                    {'start': "00:00:00", 'end': "01:00:00", 'value': 5},  # Container
+                ],
+                "expected": {
+                    '00:00:00': [0, 5],
+                    '00:05:00': [0, 5],
+                    '00:10:00': [0, 15],
+                    '00:15:00': [5, 25],
+                    '00:20:00': [5, 25],
+                    '00:25:00': [5, 25],
+                    '00:30:00': [5, 25],
+                    '00:35:00': [5, 5],
+                    '00:40:00': [5, 20],
+                    '00:45:00': [5, 20],
+                    '00:50:00': [0, 20],
+                    '00:55:00': [0, 5],
+                    '01:00:00': [0, 5],
+                }
+            }
+        ]
+
+        for case in test_cases:
+            print(f"Testing generate_time_slots: {case['description']}")
+            input_ranges = [
+                {
+                    'start': datetime.strptime(entry['start'], DTF),
+                    'end': datetime.strptime(entry['end'], DTF),
+                    'value': entry['value']
+                } for entry in case["input"]
+            ]
+
+            result = generate_time_slots(input_ranges)
+            result = format_time_slot(result)
+            try:
+                assert result == case['expected']
+                print("Passed!\n")
+            except AssertionError:
+                print(f"Test failed for '{case['description']}':")
+                print(f"Exp: {case['expected']}")
+                print(f"Got: {result} \n \n")
+
+
+def generate_time_slots(ranges):
+    """
+    Based on the ranges this function generates a dictionary of time slots with the minimum or maximum value.
+    key: [min, max] where key is a datetime and min/max are int values.
+    The key must be snapped to the resolution.
+    There can be gaps in the keys, the datetime values do not have to be successive.
+
+    :param ranges: dicts with start(datetime), end(datetime) and value (int)
+                   The start and end must be snapped to the resolution.
+    :return: dict, with the format:
+             key: [min, max] where key is a datetime and min/max are int values
+    """
+    time_slots = {}
+    sorted_ranges = sorted(ranges, key=lambda r: r['start'])
+
+    for time_range in sorted_ranges:
+        current_time = time_range['start']
+        end_time = time_range['end']
+        current_value = time_range['value']
+
+        while current_time <= end_time:
+            if current_time not in time_slots:
+                time_slots[current_time] = [current_value, current_value]
+            else:
+                min_value_to_add = min(time_slots[current_time][0], current_value)
+                max_value_to_add = max(time_slots[current_time][1], current_value)
+                time_slots[current_time] = [min_value_to_add, max_value_to_add]
+
+            current_time += c.EVENT_RESOLUTION
+
+    return time_slots
+
+
+def format_time_slot(time_slot):
+    return {k.strftime(DTF): [v] if isinstance(v, int) else v for k, v in time_slot.items()}
+
+
+def format_ranges(ranges):
+    return [(entry['start'].strftime(DTF), entry['end'].strftime(DTF), entry['value']) for entry in ranges]
+
+
+# Run the tests
+if __name__ == "__main__":
+    TestGenerateTimeSlots()

--- a/v2g-liberty/rootfs/root/tests/test_fm_client_ranges_integral.py
+++ b/v2g-liberty/rootfs/root/tests/test_fm_client_ranges_integral.py
@@ -1,0 +1,276 @@
+
+####################################### README #######################################
+#                                                                                    #
+#  This is a unit test for combining possibly overlapping time-value ranges.         #
+#  into none-overlapping time-value ranges with min or max value.                    #
+#  The aim is testing overall processing via the function consolidate_time_ranges(). #
+#                                                                                    #
+#  There are two partial test that form the fundament of this test:                  #
+#  - test_fm_client_generate_time_slots.py                                           #
+#  - test_fm_client_time_slot_to_ranges.py                                           #
+#  These separately test the functions that are used here:                           #
+#  - __generate_time_slots()                                                         #
+#  - __combine_time_slots()                                                          #
+#  Those and consolidate_time_ranges() are to be used in the fm_client.py module.    #
+#                                                                                    #
+######################################################################################
+
+from datetime import datetime, timedelta
+
+c = type('c', (), {'EVENT_RESOLUTION': timedelta(minutes=5)})
+DTF = "%H:%M:%S"
+
+class TestGenerateAndConvertTimeSlots():
+    def __init__(self):
+        self.test_generate_and_convert_time_slots()
+
+    def test_generate_and_convert_time_slots(self):
+        # Test cases formatted in HH:MM:SS for readability, code needs true datetime objects.
+        test_cases = [
+            {
+                "description": "Single range",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                ],
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                ]
+            },
+            {
+                "description": "Non-overlapping ranges",
+                # It is not possible yet to correctly process non-overlapping ranges with a one-resolution distance
+                "input": [
+                    {'start': "00:00:00", 'end': "00:05:00", 'value': 10},
+                    {'start': "00:15:00", 'end': "00:15:00", 'value': 5},
+                    {'start': "00:25:00", 'end': "00:35:00", 'value': 15},
+                ],
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "00:05:00", 'value': 10},
+                    {'start': "00:15:00", 'end': "00:15:00", 'value': 5},
+                    {'start': "00:25:00", 'end': "00:35:00", 'value': 15},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:05:00", 'value': 10},
+                    {'start': "00:15:00", 'end': "00:15:00", 'value': 5},
+                    {'start': "00:25:00", 'end': "00:35:00", 'value': 15},
+                ]
+            },
+            {
+                "description": "Overlapping ranges with min and max",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                    {'start': "00:05:00", 'end': "00:15:00", 'value': 3},
+                ],
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                    {'start': "00:10:00", 'end': "00:15:00", 'value': 3},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:05:00", 'value': 5},
+                    {'start': "00:05:00", 'end': "00:15:00", 'value': 3},
+                ]
+            },
+            {
+                "description": "Contained ranges with varying min and max",
+                "input": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 0},
+                    {'start': "00:10:00", 'end': "00:20:00", 'value': 15},
+                    {'start': "00:15:00", 'end': "00:30:00", 'value': 25},
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 0},
+                    {'start': "00:00:00", 'end': "01:00:00", 'value': 5},
+                ],
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                    {'start': "00:10:00", 'end': "00:15:00", 'value': 15},
+                    {'start': "00:15:00", 'end': "00:30:00", 'value': 25},
+                    {'start': "00:30:00", 'end': "00:40:00", 'value': 5},
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 5},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 0},
+                    {'start': "00:10:00", 'end': "00:50:00", 'value': 5},
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 0},
+                ]
+            },
+        ]
+
+        for case in test_cases:
+            print(f"Testing case: {case['description']}")
+
+            # Convert input times into datetime objects
+            input_ranges = [
+                {
+                    'start': datetime.strptime(entry['start'], DTF),
+                    'end': datetime.strptime(entry['end'], DTF),
+                    'value': entry['value']
+                } for entry in case["input"]
+            ]
+
+            result_max = consolidate_time_ranges(input_ranges, min_or_max="max")
+            result_max = format_ranges(result_max)
+            expected_max = strip_ranges_labels(case['expected_max'])
+
+            try:
+                assert result_max == expected_max
+                print("Max test passed!")
+            except AssertionError:
+                print(f"Max test failed:")
+                print(f"Exp: {expected_max}")
+                print(f"Got: {result_max}\n")
+
+            result_min = consolidate_time_ranges(input_ranges, min_or_max="min")
+            result_min = format_ranges(result_min)
+            expected_min = strip_ranges_labels(case['expected_min'])
+
+            try:
+                assert result_min == expected_min
+                print("Min test passed!\n")
+            except AssertionError:
+                print(f"Min test failed:")
+                print(f"Exp: {expected_min}")
+                print(f"Got: {result_min}\n")
+
+
+def consolidate_time_ranges(ranges, min_or_max: str = 'max'):
+    """
+    Make ranges non-overlapping and, for the overlapping parts, use min or max value from the ranges.
+
+    :param ranges: dicts with start(datetime), end(datetime) and value (int)
+                   The start and end must be snapped to the resolution.
+    :param min_or_max: str, "min" or "max" (default) to indicate if the minimum or maximum values should be used for
+                       the overlapping parts.
+    :return: a list of dicts with start(datetime), end(datetime) and value (int) that are none-overlapping,
+             but possibly 'touching' (end of A = start of B).
+
+    Note!
+    It is not possible yet to correctly process non-overlapping ranges with a one-resolution distance
+    As this is very rare in this context, and it's impact relatively small it has not been solved yet
+    and accepted as a not-perfect output.
+    """
+    if len(ranges) == 0:
+        # self.log("consolidate_time_ranges, ranges = [], aborting")
+        return []
+    elif len(ranges) == 1:
+        # self.log("consolidate_time_ranges, only one range so nothing to consolidate, returning ranges untouched.")
+        return ranges
+
+    generated_slots = __generate_time_slots(ranges)
+    return __combine_time_slots(generated_slots, min_or_max=min_or_max)
+
+
+def __generate_time_slots(ranges):
+    """
+    Based on the ranges this function generates a dictionary of time slots with the minimum or maximum value.
+    key: [min, max] where key is a datetime and min/max are int values.
+    The key must be snapped to the resolution.
+    There can be gaps in the keys, the datetime values do not have to be successive.
+
+    :param ranges: dicts with start(datetime), end(datetime) and value (int)
+                   The start and end must be snapped to the resolution.
+    :return: dict, with the format:
+             key: [min, max] where key is a datetime and min/max are int values
+    """
+    time_slots = {}
+    sorted_ranges = sorted(ranges, key=lambda r: r['start'])
+
+    for time_range in sorted_ranges:
+        current_time = time_range['start']
+        end_time = time_range['end']
+        current_value = time_range['value']
+
+        while current_time <= end_time:
+            if current_time not in time_slots:
+                time_slots[current_time] = [current_value, current_value]
+            else:
+                min_value_to_add = min(time_slots[current_time][0], current_value)
+                max_value_to_add = max(time_slots[current_time][1], current_value)
+                time_slots[current_time] = [min_value_to_add, max_value_to_add]
+
+            current_time += c.EVENT_RESOLUTION
+
+    return time_slots
+
+
+def __combine_time_slots(time_slots: dict, min_or_max: str = 'max'):
+    """
+    Merges time slots into ranges with a constant value. The value to use is based on min_or_max parameter.
+
+    :param time_slots: dict, with the format:
+                       key: [min, max] where key is a datetime and min/max are int values
+    :param min_or_max: str, "min" or "max" (default) to indicate if the minimum or maximum values should be used for
+                       the overlapping parts.
+    :return: dicts with start(datetime), end(datetime) and value (int) that are none-overlapping,
+             but possibly 'touching' (end of A = start of B).
+    """
+
+    combined_ranges = []
+    sorted_times = sorted(time_slots.keys())
+
+    min_max_index = 1 if min_or_max == 'max' else 0
+
+    # Initialize the first time slot
+    current_range_start = sorted_times[0]
+
+    # Choose the first value based on min or max
+    current_range_value = time_slots[current_range_start][min_max_index]
+
+    for i in range(1, len(sorted_times)):
+        current_time = sorted_times[i]
+        expected_time = sorted_times[i - 1] + c.EVENT_RESOLUTION
+
+        # Determine the current value based on min or max
+        time_slot_value = time_slots[current_time][min_max_index]
+
+        # If there's a break in the range times, close the current range
+        if current_time != expected_time:
+            combined_ranges.append({
+                'start': current_range_start,
+                'end': sorted_times[i - 1],
+                'value': current_range_value
+            })
+            # Start a new range
+            current_range_start = current_time
+            current_range_value = time_slot_value
+
+        # If there's a break in the range value changes, close the current range
+        elif time_slot_value != current_range_value:
+            range_end_time = current_time
+            if ((min_or_max != 'max' and time_slot_value > current_range_value)
+               or (min_or_max == 'max' and time_slot_value < current_range_value)):
+                 range_end_time = sorted_times[i - 1]
+
+            combined_ranges.append({
+                'start': current_range_start,
+                'end': range_end_time,
+                'value': current_range_value
+            })
+            # Start a new range
+            current_range_start = range_end_time
+            current_range_value = time_slot_value
+
+    # Add the last range
+    combined_ranges.append({
+        'start': current_range_start,
+        'end': sorted_times[-1],
+        'value': current_range_value
+    })
+
+    return combined_ranges
+
+# Utility functions for pretty printing
+def format_ranges(ranges):
+    return [(entry['start'].strftime(DTF), entry['end'].strftime(DTF), entry['value']) for entry in ranges]
+
+
+def strip_ranges_labels(ranges):
+    return [(entry['start'], entry['end'], entry['value']) for entry in ranges]
+
+
+# Run the integrated tests
+if __name__ == "__main__":
+    TestGenerateAndConvertTimeSlots()

--- a/v2g-liberty/rootfs/root/tests/test_fm_client_time_slots_to_ranges.py
+++ b/v2g-liberty/rootfs/root/tests/test_fm_client_time_slots_to_ranges.py
@@ -1,0 +1,240 @@
+
+####################################### README #######################################
+#                                                                                    #
+#  This is a separate unit test for __combine_time_slots() function.                 #
+#  The function is an exact copy of the one in test_fm_client-ranges_integral.py,    #
+#  and as such this test forms a fundament for the integral test.                    #
+#                                                                                    #
+######################################################################################
+
+from datetime import datetime, timedelta
+
+c = type('c', (), {'EVENT_RESOLUTION': timedelta(minutes=5)})
+DTF = "%H:%M:%S"
+
+class TestConvertTimeSlotsToRanges():
+    def __init__(self):
+        self.test_convert_time_slots_to_ranges()
+
+
+    def test_convert_time_slots_to_ranges(self):
+        test_cases = [
+            {
+                "description": "Contained with max base",
+                "input":{
+                    '00:00:00': [35, 35],
+                    '00:05:00': [35, 35],
+                    '00:10:00': [15, 35],
+                    '00:15:00': [15, 35],
+                    '00:20:00': [15, 35],
+                    '00:25:00': [25, 35],
+                    '00:30:00': [25, 35],
+                    '00:35:00': [35, 35],
+                    '00:40:00': [20, 35],
+                    '00:45:00': [20, 35],
+                    '00:50:00': [20, 35],
+                    '00:55:00': [35, 35],
+                    '01:00:00': [35, 35],
+                },
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "01:00:00", 'value': 35},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 35},
+                    {'start': "00:10:00", 'end': "00:20:00", 'value': 15},
+                    {'start': "00:20:00", 'end': "00:30:00", 'value': 25},
+                    {'start': "00:30:00", 'end': "00:40:00", 'value': 35},
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 35},
+                ]
+            },
+            # 2. Variants with higher/lower/equal values over longer time frames
+            {
+                "description": "Different value comparisons",
+                "input": {
+                    '00:00:00': [3, 5],
+                    '00:05:00': [3, 5],
+                    '00:10:00': [3, 5],
+                    '00:15:00': [3, 3],
+                },
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},  # Take max
+                    {'start': "00:10:00", 'end': "00:15:00", 'value': 3},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:15:00", 'value': 3 },  # Take min
+                ]
+            },
+            # 3. Non-overlapping with equal values but longer ranges
+            {
+                "description": " Non-overlapping",
+                "input":{
+                    '00:05:00': [35, 35],
+                    '00:10:00': [35, 35],
+                    '00:20:00': [40, 40],
+                    '00:40:00': [20, 20],
+                    '00:45:00': [20, 20],
+                    '00:50:00': [20, 20],
+                },
+                "expected_max": [
+                    {'start': "00:05:00", 'end': "00:10:00", 'value': 35},
+                    {'start': "00:20:00", 'end': "00:20:00", 'value': 40},
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},
+                ],
+                "expected_min": [
+                    {'start': "00:05:00", 'end': "00:10:00", 'value': 35},
+                    {'start': "00:20:00", 'end': "00:20:00", 'value': 40},
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},
+                ]
+            },
+            # 4. Contained with varying min and max
+            # For convenience, these are the ranges that the timeslots input is based upon.
+            # {'start': "00:00:00", 'end': "01:00:00", 'value': 5},  # Container
+            # {'start': "00:00:00", 'end': "00:10:00", 'value': 0},  # Contained
+            # {'start': "00:10:00", 'end': "00:20:00", 'value': 15},  # Contained
+            # {'start': "00:15:00", 'end': "00:30:00", 'value': 25},  # Contained
+            # {'start': "00:40:00", 'end': "00:50:00", 'value': 20},  # Contained
+            # {'start': "00:50:00", 'end': "01:00:00", 'value': 0},  # Contained
+            {
+                "description": "Contained with varying min and max",
+                "input":{
+                    '00:00:00': [0, 5],
+                    '00:05:00': [0, 5],
+                    '00:10:00': [0, 15],
+                    '00:15:00': [5, 25],
+                    '00:20:00': [5, 25],
+                    '00:25:00': [5, 25],
+                    '00:30:00': [5, 25],
+                    '00:35:00': [5, 5],
+                    '00:40:00': [5, 20],
+                    '00:45:00': [5, 20],
+                    '00:50:00': [0, 20],
+                    '00:55:00': [0, 5],
+                    '01:00:00': [0, 5],
+                },
+                "expected_max": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 5},
+                    {'start': "00:10:00", 'end': "00:15:00", 'value': 15},
+                    {'start': "00:15:00", 'end': "00:30:00", 'value': 25},
+                    {'start': "00:30:00", 'end': "00:40:00", 'value': 5},
+                    {'start': "00:40:00", 'end': "00:50:00", 'value': 20},
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 5},
+                ],
+                "expected_min": [
+                    {'start': "00:00:00", 'end': "00:10:00", 'value': 0},
+                    {'start': "00:10:00", 'end': "00:50:00", 'value': 5},
+                    {'start': "00:50:00", 'end': "01:00:00", 'value': 0},
+                ]
+            }
+        ]
+
+        for case in test_cases:
+            print(f"Testing case: {case['description']}")
+
+            input_slots = {
+                datetime.strptime(key, DTF): value for key, value in case["input"].items()
+            }
+
+            result_max = combine_time_slots(input_slots, min_or_max="max")
+            result_max = format_ranges(result_max)
+            expected_max = strip_ranges_labels(case['expected_max'])
+            try:
+                assert result_max == expected_max
+                print("Max test passed!")
+            except AssertionError:
+                print(f"Max test failed:")
+                print(f"Exp: {expected_max}")
+                print(f"Got: {result_max}")
+                print()
+
+            result_min = combine_time_slots(input_slots, min_or_max="min")
+            result_min = format_ranges(result_min)
+            expected_min = strip_ranges_labels(case['expected_min'])
+            try:
+                assert result_min == expected_min
+                print("Min test passed!\n")
+            except AssertionError:
+                print(f"Min test failed:")
+                print(f"Exp: {expected_min}")
+                print(f"Got: {result_min}\n")
+                print()
+
+
+def combine_time_slots(time_slots: dict, min_or_max: str = 'max'):
+    """
+    Merges time slots into ranges with a constant value. The value to use is based on min_or_max parameter.
+
+    :param time_slots: dict, with the format:
+                       key: [min, max] where key is a datetime and min/max are int values
+    :param min_or_max: str, "min" or "max" (default) to indicate if the minimum or maximum values should be used for
+                       the overlapping parts.
+    :return: dicts with start(datetime), end(datetime) and value (int) that are none-overlapping,
+             but possibly 'touching' (end of A = start of B).
+    """
+
+    combined_ranges = []
+    sorted_times = sorted(time_slots.keys())
+
+    min_max_index = 1 if min_or_max == 'max' else 0
+
+    # Initialize the first time slot
+    current_range_start = sorted_times[0]
+
+    # Choose the first value based on min or max
+    current_range_value = time_slots[current_range_start][min_max_index]
+
+    for i in range(1, len(sorted_times)):
+        current_time = sorted_times[i]
+        expected_time = sorted_times[i - 1] + c.EVENT_RESOLUTION
+
+        # Determine the current value based on min or max
+        time_slot_value = time_slots[current_time][min_max_index]
+
+        # If there's a break in the range times, close the current range
+        if current_time != expected_time:
+            combined_ranges.append({
+                'start': current_range_start,
+                'end': sorted_times[i - 1],
+                'value': current_range_value
+            })
+            # Start a new range
+            current_range_start = current_time
+            current_range_value = time_slot_value
+
+        # If there's a break in the range value changes, close the current range
+        elif time_slot_value != current_range_value:
+            range_end_time = current_time
+            if ((min_or_max != 'max' and time_slot_value > current_range_value)
+               or (min_or_max == 'max' and time_slot_value < current_range_value)):
+                 range_end_time = sorted_times[i - 1]
+
+            combined_ranges.append({
+                'start': current_range_start,
+                'end': range_end_time,
+                'value': current_range_value
+            })
+            # Start a new range
+            current_range_start = range_end_time
+            current_range_value = time_slot_value
+
+    # Add the last range
+    combined_ranges.append({
+        'start': current_range_start,
+        'end': sorted_times[-1],
+        'value': current_range_value
+    })
+
+    return combined_ranges
+
+
+# Utility function for pretty printing
+def format_ranges(ranges):
+    return [(entry['start'].strftime(DTF), entry['end'].strftime(DTF), entry['value']) for entry in ranges]
+
+def strip_ranges_labels(ranges):
+    return [(entry['start'], entry['end'], entry['value']) for entry in ranges]
+
+
+# Run the tests
+if __name__ == "__main__":
+    TestConvertTimeSlotsToRanges()

--- a/v2g-liberty/rootfs/root/tests/test_is_now_between.py
+++ b/v2g-liberty/rootfs/root/tests/test_is_now_between.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timedelta
+import pytz
+
+TZ = pytz.timezone("Australia/Sydney")
+
+GET_PRICES_TIME = "13:32:21"  # When to start check for prices.
+GET_EMISSIONS_TIME = "13:45:26"  # When to start check for emissions.
+TRY_UNTIL = "11:22:33"  # If not successful retry every x minutes until this time (the next day)
+
+
+class TestIsNowBetween():
+    def init(self):
+        # TESTING
+        test_cases = [
+            ("15:00:00", "13:30:00", "18:30:00", True),
+            ("17:13:53", "13:32:21", "23:59:59", True),
+            ("19:00:00", "13:30:00", "00:00:00", True),
+            ("10:00:00", "13:30:00", "23:59:59", False),
+            ("10:00:00", "13:30:00", "15:30:00", False),
+            ("19:00:00", "13:30:00", "15:30:00", False),
+            ("12:00:00", "13:30:00", "11:30:00", False),
+            ("01:00:00", "13:30:00", "11:30:00", True),
+            (None, "13:32:21", "11:22:33", True),
+        ]
+
+        for now_time, start_time, end_time, expected in test_cases:
+            result = is_local_now_between(start_time = start_time, end_time = end_time, now_time = now_time)
+            print(f"Test: {start_time=}, {end_time=}, {now_time=}, assert: {result == expected}.")
+
+        result = is_local_now_between(start_time = GET_PRICES_TIME, end_time = TRY_UNTIL)
+        print(f"Test: start_time={GET_PRICES_TIME}, end_time={TRY_UNTIL}, assert: {result == True}.")
+
+
+def is_local_now_between(start_time: str, end_time: str, now_time: str = None) -> bool:
+    # Get today's date
+    today_date = datetime.today().date()
+
+    if now_time is None:
+        now = get_local_now()
+    else:
+        time_obj = datetime.strptime(now_time, "%H:%M:%S").time()
+        now = TZ.localize(datetime.combine(today_date, time_obj))
+
+    time_obj = datetime.strptime(start_time, "%H:%M:%S").time()
+    start_dt = TZ.localize(datetime.combine(today_date, time_obj))
+
+    time_obj = datetime.strptime(end_time, "%H:%M:%S").time()
+    end_dt = TZ.localize(datetime.combine(today_date, time_obj))
+
+    # Comparisons
+    if end_dt < start_dt:
+        # self.log(f"is_local_now_between, end_dt < start_dt ...")
+        # Start and end time backwards, so it spans midnight.
+        # Let's start by assuming end_dt is wrong and should be tomorrow.
+        # This will be true if we are currently after start_dt
+        end_dt += timedelta(days=1)
+        if now < start_dt and now < end_dt:
+            # Well, it's complicated, we crossed into a new day and things changed.
+            # Now all times have shifted relative to the new day, so we need to look at it differently
+            # If both times are now in the future, we now actually need to set start_dt and end_dt back a day.
+            start_dt -= timedelta(days=1)
+            end_dt -= timedelta(days=1)
+
+    result = (start_dt <= now <= end_dt)
+    print(f"is_local_now_between start: {start_dt.isoformat()}, end: {end_dt.isoformat()},"
+          f" now: {now.isoformat()} => result: {result}.")
+    return result
+
+def get_local_now():
+    return TZ.localize(datetime.now())
+
+if __name__ == '__main__':
+    TestIsNowBetween().init()


### PR DESCRIPTION
To achieve this feature:
- The max_consumption_power_ranges and max_production_power_ranges are added to the flex-model.
- To make schedules more logical to the user the allowed_duration_above_max_soc now has a default of 4 hrs and a max of 12 hrs. This prevents schedules that only discharge during 36 hours. If a setting higher than 12 hrs was set by the user this will automatically be changed to 12 hrs.
- fm_client processing of ranges has been altered so that the ranges can 'touch' (end of range A = start of range B)<br/>
   As this was a mayor rebuild, tests (test_fm_client_...) have been added to the tests-folder.

- Removed old unused template sensor for timezone from v2g_liberty_package.yaml