### PR TITLE
Improve initial creating of devcontainer

### DIFF
--- a/v2g-liberty/.devcontainer/devcontainer.json
+++ b/v2g-liberty/.devcontainer/devcontainer.json
@@ -2,8 +2,7 @@
   "name": "V2G-Liberty App Dev",
   "dockerComposeFile": "docker-compose.yaml",
   "service": "v2g-liberty",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "onCreateCommand": "script/init-config",
+  "workspaceFolder": "/workspaces/v2g-liberty",
   "containerEnv": {
     "PYTHONASYNCIODEBUG": "1"
   },

--- a/v2g-liberty/.devcontainer/docker-compose.yaml
+++ b/v2g-liberty/.devcontainer/docker-compose.yaml
@@ -11,7 +11,12 @@ services:
       - ./config:/homeassistant
       - ../data:/data
       - ../logs:/config/logs
-    command: sleep infinity
+    command: sh -c "/workspaces/v2g-liberty/script/init-config && sleep infinity"
+    healthcheck:
+      test: ['CMD', '/workspaces/v2g-liberty/script/is-container-ready']
+      interval: 3s
+      timeout: 1s
+      retries: 100
 
   homeassistant:
     image: homeassistant/home-assistant:2024.10
@@ -21,4 +26,5 @@ services:
     volumes:
       - ./config:/config
     depends_on:
-      - v2g-liberty
+      v2g-liberty:
+        condition: service_healthy

--- a/v2g-liberty/script/init-config
+++ b/v2g-liberty/script/init-config
@@ -5,6 +5,12 @@ set -e
 
 cd "$(dirname "$0")/../.devcontainer"
 
+# Do not overwrite existing config
+if [ -e config/.ready ]; then exit 0; fi
+
 if [ ! -x config ]; then mkdir config; fi
 rm -rf config/.* config/*
 cp -avR init-config/.* init-config/* config
+
+# Signal we are done copying
+touch config/.ready

--- a/v2g-liberty/script/is-container-ready
+++ b/v2g-liberty/script/is-container-ready
@@ -1,0 +1,9 @@
+#!/usr/bin/bash -x
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/../.devcontainer"
+
+[ -e config/.ready ]
+exit $?


### PR DESCRIPTION
Changed the initialisation sequence of creating/starting the devcontainers to make it more robust.
It now includes a "healthcheck" that ensures that copying the initial config is finished, before starting the HomeAssistant container.