### PR TITLE
#152 🪲 BUG: During Max charge the power is set to 0 every now and then

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/constants.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/constants.py
@@ -36,6 +36,10 @@ CAR_MAX_SOC_IN_PERCENT: int = 80
 # Derived from above setting and CAR_MAX_CAPACITY_IN_KWH
 CAR_MAX_SOC_IN_KWH: float = 0
 
+# A practical absolute max. capacity of the car battery in percent.
+# E.g. a Quasar + Nissan Leaf will never charge higher than 97%.
+CAR_MAX_CAPACITY_IN_PERCENT: int = 97
+
 # Car consumption per km. Defaults to the Nissan Leaf average.
 CAR_CONSUMPTION_WH_PER_KM: int = 175
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/get_fm_data.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/get_fm_data.py
@@ -218,6 +218,8 @@ class FlexMeasuresDataImporter(hass.Hass):
         self.log(f"get_charging_cost | sensor_id: {c.FM_ACCOUNT_COST_SENSOR_ID}, charging_costs: {charging_costs}.")
 
         if charging_costs is None:
+            self.log("get_charging_cost, get_sensor_data on fm_client_app returned None,"
+                     " aborting.", level="WARNING")
             # TODO: When to retry?
             return
 
@@ -276,13 +278,18 @@ class FlexMeasuresDataImporter(hass.Hass):
             self.log(f"get_charged_energy. Could not call get_sensor_data on fm_client_app as it is None.")
             return False
 
+        if res is None:
+            self.log("get_charged_energy | get_sensor_data on fm_client_app returned None,"
+                     " aborting.", level="WARNING")
+            return
+
         # The res structure:
         # 'duration': 'PT168H',
         # 'start': '2024-09-02T00:00:00+02:00',
         # 'unit': 'MW',
         # 'values': [0.004321, None, ..., 0.005712]
-        self.log(f"get_charged_energy sensor_id: {c.FM_ACCOUNT_POWER_SENSOR_ID}, "
-                 f"charge power response: {str(res)[:75]} ... {str(res)[-25:]}.")
+        self.log(f"get_charged_energy | sensor_id: {c.FM_ACCOUNT_POWER_SENSOR_ID}, "
+                 f"charge power response: {str(res)[:100]} ... {str(res)[-25:]}.")
 
         total_charged_energy_last_7_days = 0
         total_discharged_energy_last_7_days = 0
@@ -417,7 +424,7 @@ class FlexMeasuresDataImporter(hass.Hass):
                     # emissions yet, than it communicates the emissions it does have.
                     date_tomorrow = now + timedelta(days=1)
                     date_tomorrow = time_ceil(date_tomorrow, timedelta(days=1))
-                    # As the price is for the hour 23:00 - 23:59:59 we need to
+                    # As the emission is for the hour 23:00 - 23:59:59 we need to
                     # subtract one hour and, to give some slack, 1x resolution
                     date_tomorrow += timedelta(minutes=-(60 + c.FM_EVENT_RESOLUTION_IN_MINUTES))
                     if date_latest_emission < date_tomorrow:
@@ -524,12 +531,12 @@ class FlexMeasuresDataImporter(hass.Hass):
                 # To make the step-line in the chart extend to the end of the last (half)hour (or what the resolution
                 # might be), a value is added at the end. Not an ideal solution but the chart does not have the option
                 # to do this.
-                data_point = {
-                    'time': (dt + timedelta(minutes=c.PRICE_RESOLUTION_MINUTES)).isoformat(),
-                    'price': net_price
-                }
-
-                price_points.append(data_point)
+                if net_price is not None:
+                    data_point = {
+                        'time': (dt + timedelta(minutes=c.PRICE_RESOLUTION_MINUTES)).isoformat(),
+                        'price': net_price
+                    }
+                    price_points.append(data_point)
 
 
                 await self.v2g_main_app.set_records_in_chart(
@@ -543,17 +550,17 @@ class FlexMeasuresDataImporter(hass.Hass):
                     # We expect prices till the end of the day tomorrow (or today if prices are really late).
                     if is_local_now_between(start_time=self.GET_PRICES_TIME, end_time="23:59:59"):
                         expected_price_dt = now + timedelta(days=1)
-                        self.log(f"get_prices, set expected_price_dt is tomorrow.")
+                        # self.log(f"get_prices, set expected_price_dt is tomorrow.")
                     else:
                         expected_price_dt = now
-                        self.log(f"get_prices, set expected_price_dt is today.")
+                        # self.log(f"get_prices, set expected_price_dt is today.")
                     # Round it to the end of the day
                     expected_price_dt = time_ceil(expected_price_dt, timedelta(days=1))
-                    self.log(f"get_prices, set expected_price_dt C {expected_price_dt=}.")
+                    # self.log(f"get_prices, set expected_price_dt C {expected_price_dt=}.")
                     # As the last price is valid for the hour 23:00:00 - 23:59:59 so we need to subtract one hour
                     # and a little extra to give it some slack.
                     expected_price_dt -= timedelta(minutes=65)
-                    self.log(f"get_prices, set expected_price_dt D {expected_price_dt=}.")
+                    # self.log(f"get_prices, set expected_price_dt D {expected_price_dt=}.")
                     is_up_to_date = date_latest_price > expected_price_dt
                     if not is_up_to_date:
                         # Set it in th UI right away, no matter which price type it is.

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
@@ -606,85 +606,83 @@ automation:
       Te give these buttons a on/off state for each of them a toggle helper is used.
 
       When a toggle-button is clicked an (these) automations receives the trigger selects
-      the corresponding item in the input_select and switches the other toggles to off.'
-    trigger:
-      - platform: state
-        entity_id: input_boolean.chargemodeautomatic
+      the corresponding item in the input_select and switches the other toggles to off.
+            
+      If these seem not to work, check in the settings > automations to see if they are active.'
+
+    triggers:
+      - trigger: state
+        entity_id:
+          - input_boolean.chargemodeautomatic
         from: "off"
         to: "on"
-    condition: []
-    action:
-      - service: input_select.select_option
-        target:
-          entity_id: input_select.charge_mode
+    conditions: []
+    actions:
+      - action: input_select.select_option
+        metadata: {}
         data:
           option: Automatic
-      - service: input_boolean.turn_off
         target:
-          entity_id: input_boolean.chargemodemaxboostnow
-      - service: input_boolean.turn_off
+          entity_id: input_select.charge_mode
+      - action: input_boolean.turn_off
+        metadata: {}
+        data: {}
         target:
-          entity_id: input_boolean.chargemodeoff
+          entity_id:
+            - input_boolean.chargemodemaxboostnow
+            - input_boolean.chargemodeoff
     mode: single
+
+
   - id: "1633010167089"
     alias: Chargemode to Max boost now
-    description: 'A bit of a hack because HA does not provide radiobuttons
-
-      The values of the helper "input_select.charge_mode" are to be reflected in the
-      UI as 3 (radio)buttons.
-
-      Te give these buttons a on/off state for each of them a toggle helper is used.
-
-      When a toggle-button is clicked an (these) automations receives the trigger selects
-      the corresponding item in the input_select and switches the other toggles to off.'
-    trigger:
-      - platform: state
-        entity_id: input_boolean.chargemodemaxboostnow
+    description: See automation Chargemode to Automatic
+    triggers:
+      - trigger: state
+        entity_id:
+          - input_boolean.chargemodemaxboostnow
         from: "off"
         to: "on"
-    condition: []
-    action:
-      - service: input_select.select_option
-        target:
-          entity_id: input_select.charge_mode
+    conditions: []
+    actions:
+      - action: input_select.select_option
+        metadata: {}
         data:
           option: Max boost now
-      - service: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.chargemodeautomatic
-      - service: input_boolean.turn_off
-        target:
-          entity_id: input_boolean.chargemodeoff
-    mode: single
-  - id: "1633010384766"
-    alias: Chargemode to Off
-    description: 'A bit of a hack because HA does not provide radiobuttons
-
-      The values of the helper "input_select.charge_mode" are to be reflected in the
-      UI as 3 (radio)buttons.
-
-      Te give these buttons a on/off state for each of them a toggle helper is used.
-
-      When a toggle-button is clicked an (these) automations receives the trigger selects
-      the corresponding item in the input_select and switches the other toggles to off.'
-    trigger:
-      - platform: state
-        entity_id: input_boolean.chargemodeoff
-        from: "off"
-        to: "on"
-    condition: []
-    action:
-      - service: input_select.select_option
         target:
           entity_id: input_select.charge_mode
+      - action: input_boolean.turn_off
+        metadata: {}
+        data: {}
+        target:
+          entity_id:
+            - input_boolean.chargemodeautomatic
+            - input_boolean.chargemodeoff
+    mode: single
+
+
+  - id: "1633010384766"
+    alias: Chargemode to Off
+    description: See automation Chargemode to Automatic
+    triggers:
+      - trigger: state
+        entity_id:
+          - input_boolean.chargemodeoff
+        from: "off"
+        to: "on"
+    conditions: []
+    actions:
+      - action: input_select.select_option
+        metadata: {}
         data:
           option: Stop
-      - service: input_boolean.turn_off
         target:
-          entity_id: input_boolean.chargemodeautomatic
+          entity_id: input_select.charge_mode
+      - action: input_boolean.turn_off
+        metadata: {}
         data: {}
-      - service: input_boolean.turn_off
         target:
-          entity_id: input_boolean.chargemodemaxboostnow
-        data: {}
+          entity_id:
+            - input_boolean.chargemodeautomatic
+            - input_boolean.chargemodemaxboostnow
     mode: single


### PR DESCRIPTION
- When the charge-mode changes from Automatic to Max charge the charge timers are cancelled.
- Added 'source' to some method calls for debugging.
- Made the Automations for setting the charge-mode in the UI comply with the new (HA 2024.10) style yaml. This makes this new version of HA required.

- Also added a more practical max SoC for the car battery of 97% as the car will never charge higher than that (partly related).
- Also prevented a exception for a None result for getting charged energy (not related).