### PR TITLE
#176 Feature Request: Add history to V2G Liberty entities

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Added
 
 - Feature Request: Notify user when at the end of a calendar item the car is not connected (#158)
+- Feature Request: Add history to V2G Liberty entities (#176) 
 
 ### Changed
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -14,6 +14,7 @@ That file also contains possible changes that the next release might include.
 ### Added
 
 - Feature Request: Notify user when at the end of a calendar item the car is not connected (#158)
+- Feature Request: Add history to V2G Liberty entities (#176) 
 
 ### Changed
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/amber_price_data_manager.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/amber_price_data_manager.py
@@ -84,7 +84,7 @@ class ManageAmberPriceData:
         """
         if c.ELECTRICITY_PROVIDER != "au_amber_electric":
             self.__log(
-                f"Not kicking off ManageAmberPriceData module. Electricity provider is not 'au_amber_electric'."
+                "Not kicking off ManageAmberPriceData module. Electricity provider is not 'au_amber_electric'."
             )
             return
 
@@ -93,7 +93,7 @@ class ManageAmberPriceData:
             or c.HA_OWN_PRODUCTION_PRICE_ENTITY_ID is None
         ):
             self.__log(
-                f"Not kicking off ManageAmberPriceData module, price entity_id's are not populated (yet)."
+                "Not kicking off ManageAmberPriceData module, price entity_id's are not populated (yet)."
             )
             return
 
@@ -112,7 +112,7 @@ class ManageAmberPriceData:
             interval=self.POLLING_INTERVAL_SECONDS,
         )
 
-        self.__log(f"kick_off_amber_price_management completed")
+        self.__log(f"completed")
 
     async def __check_for_price_changes(self, kwargs):
         """Checks if prices have changed.
@@ -122,7 +122,7 @@ class ManageAmberPriceData:
         + Request a new schedule
         """
         forced = kwargs.get("forced", False)
-        self.__log(f"__check_for_price_changes, forced: {forced}.")
+        self.__log(f"forced: {forced}.")
 
         new_schedule_needed = False
 
@@ -147,7 +147,7 @@ class ManageAmberPriceData:
             emissions.append(100 - int(float(item[self.EMISSION_LABEL])))
 
         if consumption_prices != self.last_consumption_prices or forced:
-            self.__log("__check_for_price_changes: consumption_prices changed")
+            self.__log("consumption_prices changed")
             start_cpf = parse_to_rounded_local_datetime(
                 collection_cpf[0][self.START_LABEL]
             )
@@ -168,9 +168,7 @@ class ManageAmberPriceData:
                     uom = uom,
                 )
             else:
-                self.__log(
-                    f"__check_for_price_changes. 1 Could not call post_measurements on fm_client_app as it is None."
-                )
+                self.__log("1 Could not call post_measurements on fm_client_app as it is None.")
                 res = False
 
             if res:

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
@@ -94,7 +94,7 @@ class DataMonitor:
 
         await self.hass.listen_state(
             self.__handle_charger_state_change,
-            "sensor.charger_charger_state",
+            "sensor.charger_state_int",
             attribute="all",
         )
         await self.hass.listen_state(
@@ -125,11 +125,11 @@ class DataMonitor:
         self.soc_readings = []
         await self.hass.listen_state(
             self.__handle_soc_change,
-            "sensor.charger_connected_car_state_of_charge",
+            "sensor.car_state_of_charge",
             attribute="all",
         )
         soc = await self.hass.get_state(
-            "sensor.charger_connected_car_state_of_charge", "state"
+            "sensor.car_state_of_charge", "state"
         )
         self.__log(f"init soc: {soc}.")
         if soc is not None and soc != "unavailable":

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -10,7 +10,7 @@ from appdaemon.plugins.hass.hassapi import Hass
 class FMClient:
     """This class manages the communication with the FlexMeasures platform, which delivers the charging schedules.
 
-    - Saves charging schedule locally (input_text.chargeschedule)
+    - Saves charging schedule locally (sensor.charge_schedule)
     - Reports on errors via v2g_liberty module handle_no_schedule()
 
     """
@@ -653,8 +653,8 @@ class FMClient:
 
         # To trigger state change we add the date to the state. State change is not triggered by attributes.
         await self.hass.set_state(
-            entity_id="input_text.chargeschedule",
-            state="ChargeScheduleAvailable"
+            entity_id="sensor.charge_schedule",
+            state="Charge schedule available "
             + self.fm_date_time_last_schedule.isoformat(),
             attributes=schedule,
         )

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/get_fm_data.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/get_fm_data.py
@@ -234,8 +234,7 @@ class FlexMeasuresDataImporter:
         """Communicate with FM server and check the results.
 
         Request charging costs of last 7 days from the server
-        Make costs total costs of this period available in HA by setting them in input_text.last
-        week costs.
+        Make costs total costs of this period available in HA by setting them in sensor
         ToDo: Split cost in charging and dis-charging per day
         """
         self.__log("Called")
@@ -292,15 +291,15 @@ class FlexMeasuresDataImporter:
             f"Cost data: {charging_cost_points}, total costs: {total_charging_cost_last_7_days}"
         )
 
-        # To make sure HA considers this as new info a datetime is added
-        new_state = "Costs collected at " + now.isoformat()
-        result = {"records": charging_cost_points}
+        # Seems to be un-used.
+        # new_state = "Costs collected at " + now.isoformat()
+        # result = {"records": charging_cost_points}
+        # await self.hass.set_state(
+        #     entity_id="input_text.charging_costs", state=new_state, attributes=result
+        # )
         await self.hass.set_state(
-            "input_text.charging_costs", state=new_state, attributes=result
-        )
-        await self.hass.set_value(
-            "input_number.total_charging_cost_last_7_days",
-            total_charging_cost_last_7_days,
+            entity_id="sensor.total_charging_cost_last_7_days",
+            state=total_charging_cost_last_7_days,
         )
 
     async def get_charged_energy(self, *args, **kwargs):
@@ -403,38 +402,39 @@ class FlexMeasuresDataImporter:
             total_emissions_last_7_days * conversion_factor, 1
         )
 
-        await self.hass.set_value(
-            "input_number.total_discharged_energy_last_7_days",
-            total_discharged_energy_last_7_days,
+        await self.hass.set_state(
+            entity_id="sensor.total_discharged_energy_last_7_days",
+            state=total_discharged_energy_last_7_days,
         )
-        await self.hass.set_value(
-            "input_number.total_charged_energy_last_7_days",
-            total_charged_energy_last_7_days,
+        await self.hass.set_state(
+            entity_id="sensor.total_charged_energy_last_7_days",
+            state=total_charged_energy_last_7_days,
         )
-        await self.hass.set_value(
-            "input_number.net_energy_last_7_days",
-            total_charged_energy_last_7_days + total_discharged_energy_last_7_days,
-        )
-
-        await self.hass.set_value(
-            "input_number.total_saved_emissions_last_7_days",
-            total_saved_emissions_last_7_days,
-        )
-        await self.hass.set_value(
-            "input_number.total_emissions_last_7_days", total_emissions_last_7_days
-        )
-        await self.hass.set_value(
-            "input_number.net_emissions_last_7_days",
-            total_emissions_last_7_days + total_saved_emissions_last_7_days,
+        await self.hass.set_state(
+            entity_id="sensor.net_energy_last_7_days",
+            state=total_charged_energy_last_7_days + total_discharged_energy_last_7_days,
         )
 
-        await self.hass.set_value(
-            "input_text.total_discharge_time_last_7_days",
-            format_duration(total_minutes_discharged),
+        await self.hass.set_state(
+            entity_id="sensor.total_saved_emissions_last_7_days",
+            state=total_saved_emissions_last_7_days,
         )
-        await self.hass.set_value(
-            "input_text.total_charge_time_last_7_days",
-            format_duration(total_minutes_charged),
+        await self.hass.set_state(
+            entity_id="sensor.total_emissions_last_7_days",
+            state=total_emissions_last_7_days,
+        )
+        await self.hass.set_state(
+            entity_id="sensor.net_emissions_last_7_days",
+            state=total_emissions_last_7_days + total_saved_emissions_last_7_days,
+        )
+
+        await self.hass.set_state(
+            entity_id="sensor.total_discharge_time_last_7_days",
+            state=format_duration(total_minutes_discharged),
+        )
+        await self.hass.set_state(
+            entity_id="sensor.total_charge_time_last_7_days",
+            state=format_duration(total_minutes_charged),
         )
         self.__log(
             f"stats: \n"

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
@@ -313,7 +313,7 @@ class ReservationsClient(ServiceResponseApp):
 
         attributes = {"keep_alive": start}
         await self.hass.set_state(
-            "input_text.calendar_account_connection_status",
+            "sensor.calendar_account_connection_status",
             state="Successfully connected",
             attributes=attributes,
         )

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -353,7 +353,7 @@ class V2GLibertyGlobals(ServiceResponseApp):
 
         # For showing this maximum in the UI.
         await self.hass.set_state(
-            "input_text.charger_max_available_power", state=max_available_charge_power
+            "sensor.charger_max_available_power", state=max_available_charge_power
         )
 
         kwargs = {"run_once": True}
@@ -492,7 +492,7 @@ class V2GLibertyGlobals(ServiceResponseApp):
         self.__log("__init_caldav_calendar called")
 
         await self.hass.set_state(
-            "input_text.calendar_account_connection_status",
+            "sensor.calendar_account_connection_status",
             state="Getting calendars...",
         )
 
@@ -506,7 +506,7 @@ class V2GLibertyGlobals(ServiceResponseApp):
 
         if res != "Successfully connected":
             await self.hass.set_state(
-                "input_text.calendar_account_connection_status", state=res
+                "sensor.calendar_account_connection_status", state=res
             )
             self.__log(f"__init_caldav_calendar, res: {res}.")
             return
@@ -516,7 +516,7 @@ class V2GLibertyGlobals(ServiceResponseApp):
 
         # A conditional card in the dashboard is dependent on exactly the text "Successfully connected".
         await self.hass.set_state(
-            "input_text.calendar_account_connection_status",
+            "sensor.calendar_account_connection_status",
             state="Successfully connected",
         )
 
@@ -754,7 +754,7 @@ class V2GLibertyGlobals(ServiceResponseApp):
     async def __set_fm_connection_status(self, state: str):
         self.__log(f"__set_fm_connection_status, state: {state}.")
         await self.hass.set_state(
-            "input_text.fm_connection_status", state=state, attributes=get_keepalive()
+            "sensor.fm_connection_status", state=state, attributes=get_keepalive()
         )
 
     async def create_persistent_notification(

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/main_view.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/main_view.yaml
@@ -7,13 +7,13 @@
   cards:
     - type: markdown
       entities:
-        - entity: input_text.charger_state
+        - entity: sensor.charger_state_text
         - entity: sensor.charger_real_charging_power
       content: >-
         <ha-icon icon="mdi:ev-station"></ha-icon> <div title="Polling
         charger">&nbsp;{{
-        states('input_text.poll_refresh_indicator')}}</div>
-        <table><tbody><tr><th> {{ states('input_text.charger_state') }}
+        states('sensor.poll_refresh_indicator')}}</div>
+        <table><tbody><tr><th> {{ states('sensor.charger_state_text') }}
         </th><td> {{ states('sensor.charger_real_charging_power')
         }}&nbsp;Watt </td></tr></tbody></table>
       layout_options:
@@ -54,7 +54,7 @@
             }
     - type: conditional
       conditions:
-        - entity: input_text.charger_state
+        - entity: sensor.charger_state_text
           state: "Connected: controlled by Wallbox App"
         - entity: input_boolean.chargemodeoff
           state: "off"
@@ -84,8 +84,8 @@
 
     - type: conditional
       conditions:
-        - entity: sensor.charger_charger_state
-          state: "0"
+        - entity: sensor.charger_state_text
+          state: "No car connected"
         - entity: sensor.charger_locked
           state: "1"
       card:
@@ -149,13 +149,13 @@
       layout_options:
         grid_columns: 3
       entities:
-        - entity: input_number.car_state_of_charge
-        - entity: input_number.car_remaining_range
-        - entity: input_text.charger_state
+        - entity: sensor.car_state_of_charge
+        - entity: sensor.car_remaining_range
+        - entity: sensor.charger_state_text
       content: |-
         <table><tr>
-          <th>{{ states("input_number.car_state_of_charge")|round(0)}}%</th>
-          <td>≈ {{ states("input_number.car_remaining_range")|round(0)}} km</td>
+          <th>{{ states("sensor.car_state_of_charge")|round(0)}}%</th>
+          <td>≈ {{ states("sensor.car_remaining_range")|round(0)}} km</td>
         </tr></table> <div><span>&nbsp;</span></div>
       card_mod:
         style:
@@ -168,19 +168,19 @@
               filter: grayscale(var(--v2g-state-grayscale));
             }
             :host {
-              --v2g-empty-capacity-width: {{ 100 - states('input_number.car_state_of_charge')|int }}%;
+              --v2g-empty-capacity-width: {{ 100 - states('sensor.car_state_of_charge')|int }}%;
 
-              --v2g-dynamic-charge-bar-color: {% if states('input_number.car_state_of_charge')|int < 7 %}
+              --v2g-dynamic-charge-bar-color: {% if states('sensor.car_state_of_charge')|int < 7 %}
                 var(--error-color);
-              {% elif states('input_number.car_state_of_charge')|int < 20 %}
+              {% elif states('sensor.car_state_of_charge')|int < 20 %}
                 var(--warning-color);
-              {% elif states('input_number.car_state_of_charge')|int > 80 %}
+              {% elif states('sensor.car_state_of_charge')|int > 80 %}
                 var(--warning-color);
               {% else %}
                 var(--success-color);
               {% endif %};
 
-              {% if states('input_text.charger_state') in ['No car connected', 'Error', 'No car connected and charger locked'] %}
+              {% if states('sensor.charger_state_text') in ['No car connected', 'Error', 'No car connected and charger locked'] %}
               --v2g-state-grayscale: 1;
               {% else %}
               --v2g-state-grayscale: 0;
@@ -291,7 +291,7 @@
           }
     - type: conditional
       conditions:
-        - entity: input_text.charger_state
+        - entity: sensor.charger_state_text
           state: No car connected
         - entity: input_boolean.chargemodemaxboostnow
           state: "on"
@@ -351,7 +351,7 @@
         show: true
         title: Car State of Charge (%)
       series:
-        - entity: input_text.calender_item_in_chart
+        - entity: sensor.calender_item_in_chart
           show:
             legend_value: false
           type: area
@@ -364,7 +364,7 @@
             return entity.attributes.records.map((record, index) => {
               return [new Date(record.time).getTime(), record.soc];
             });
-        - entity: input_text.soc_prognosis_max_charge_now
+        - entity: sensor.soc_prognosis_max_charge_now
           show:
             legend_value: false
           type: line
@@ -378,7 +378,7 @@
             return entity.attributes.records.map((record, index) => {
               return [new Date(record.time).getTime(), record.soc];
             });
-        - entity: input_text.soc_prognosis_boost
+        - entity: sensor.soc_prognosis_boost
           show:
             legend_value: false
           type: line
@@ -391,7 +391,7 @@
             return entity.attributes.records.map((record, index) => {
               return [new Date(record.time).getTime(), record.soc];
             });
-        - entity: input_text.co2_emissions
+        - entity: sensor.co2_emissions
           show:
             hidden_by_default: true
             legend_value: false
@@ -407,7 +407,7 @@
               return [new Date(record.time).getTime(), record.emission];
             });
           type: line
-        - entity: input_text.production_prices
+        - entity: sensor.production_prices
           show:
             hidden_by_default: true
             legend_value: false
@@ -429,7 +429,7 @@
               return [new Date(record.time).getTime(), record.price];
             });
           type: line
-        - entity: input_text.consumption_prices
+        - entity: sensor.consumption_prices
           show:
             legend_value: false
           color_threshold:
@@ -450,7 +450,7 @@
               return [new Date(record.time).getTime(), record.price];
             });
           type: line
-        - entity: input_text.soc_prognosis
+        - entity: sensor.soc_prognosis
           show:
             legend_value: false
           type: line
@@ -462,7 +462,7 @@
             return entity.attributes.records.map((record, index) => {
               return [new Date(record.time).getTime(), record.soc];
             });
-        - entity: input_number.car_state_of_charge
+        - entity: sensor.car_state_of_charge
           show:
             legend_value: false
           color: "#009be5"
@@ -500,20 +500,20 @@
             top: 50px;
           }
           div[seriesname="Calendarxitemxinxchart"],
-          div[seriesname="SoCxBoost"],
-          div[seriesname="SoCxMaxxChargexNow"] {
+          div[seriesname="SoCxBoostxchartxdata"],
+          div[seriesname="SoCxMaxxChargexNowxchartxdata"] {
             display: none;
           }
     - type: markdown
       layout_options:
         grid_columns: full
       entities:
-        - entity: input_text.optimisation_mode
-        - entity: input_text.utility_display_name
+        - entity: sensor.optimisation_mode
+        - entity: sensor.utility_display_name
       content: >-
         <table><tbody><tr><th>Optimised on
-        <span>{{states("input_text.optimisation_mode")}}</span> </th><td>
-        {{states("input_text.utility_display_name")}}
+        <span>{{states("sensor.optimisation_mode")}}</span> </th><td>
+        {{states("sensor.utility_display_name")}}
         </td></tr></tbody></table>
       card_mod:
         style:
@@ -591,16 +591,16 @@
     - type: markdown
       title: Reservations
       entities:
-        - input_text.input_text.calendar_events
+        - sensor.calendar_events
       content: >-
         <div>Target SoC is read from the event summary, if not found, 100%
-        is used.</div>  {% if state_attr('input_text.calendar_events',
+        is used.</div>  {% if state_attr('sensor.calendar_events',
         'v2g_ui_event_calendar') == None %} Calendar configuration seems
         invalid, please check settings. {% else %} {% if
-        states.input_text.calendar_events.attributes.v2g_ui_event_calendar
+        states.sensor.calendar_events.attributes.v2g_ui_event_calendar
         == [] %} No reservations in the next seven days. {% else %}
         <table>{% for cal_day in
-        states.input_text.calendar_events.attributes.v2g_ui_event_calendar
+        states.sensor.calendar_events.attributes.v2g_ui_event_calendar
         %} <thead> <tr> <th colspan=4>{{ as_timestamp(cal_day.day) |
         timestamp_custom("%A") }}</th> <td>{{ as_timestamp(cal_day.day) |
         timestamp_custom("%Y-%m-%d") }}</td> </tr> </thead>{% for event in
@@ -680,16 +680,16 @@
       layout_options:
         grid_columns: full
       entities:
-        - entity: input_number.total_charging_cost_last_7_days
-        - entity: input_number.net_energy_last_7_days
-        - entity: input_text.total_charge_time_last_7_days
-        - entity: input_number.total_emissions_last_7_days
-        - entity: input_number.total_charged_energy_last_7_days
-        - entity: input_text.total_discharge_time_last_7_days
-        - entity: input_number.total_saved_emissions_last_7_days
-        - entity: input_number.total_discharged_energy_last_7_days
-        - entity: input_number.net_emissions_last_7_days
-        - entity: input_number.net_energy_last_7_days
+        - entity: sensor.total_charging_cost_last_7_days
+        - entity: sensor.net_energy_last_7_days
+        - entity: sensor.total_charge_time_last_7_days
+        - entity: sensor.total_emissions_last_7_days
+        - entity: sensor.total_charged_energy_last_7_days
+        - entity: sensor.total_discharge_time_last_7_days
+        - entity: sensor.total_saved_emissions_last_7_days
+        - entity: sensor.total_discharged_energy_last_7_days
+        - entity: sensor.net_emissions_last_7_days
+        - entity: sensor.net_energy_last_7_days
       content: !include v2g_liberty_ui_module_stats.yaml
       card_mod:
         style: !include table_style.yaml
@@ -697,8 +697,6 @@
     - type: markdown
       layout_options:
         grid_columns: full
-      entities:
-        - input_text.v2g_liberty_version
       content: >-
         Version <span>{{ state_attr("update.v2g_liberty_update",
         "installed_version") }}</span>

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/settings_view.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/settings_view.yaml
@@ -102,13 +102,13 @@
           }
     - type: markdown
       entities:
-        - input_text.charger_connection_status
-        - input_text.charger_max_available_power
+        - sensor.charger_connection_status
+        - sensor.charger_max_available_power
       content: >-
-        {{ states("input_text.charger_connection_status")}} |
-        {{ (now().timestamp() - states.input_text.charger_connection_status.last_reported.timestamp()) | timestamp_custom('%H:%M:%S', False) }} ago
+        {{ states("sensor.charger_connection_status")}} |
+        {{ (now().timestamp() - states.sensor.charger_connection_status.last_reported.timestamp()) | timestamp_custom('%H:%M:%S', False) }} ago
         <div>&nbsp;</div>
-        The charger is set to provide max. **{{ states("input_text.charger_max_available_power")}}**&nbsp;W
+        The charger is set to provide max. **{{ states("sensor.charger_max_available_power")}}**&nbsp;W
       card_mod:
         style:
           .: |
@@ -129,7 +129,7 @@
     - type: conditional
       conditions:
         - condition: state
-          entity: input_text.charger_connection_status
+          entity: sensor.charger_connection_status
           state: "Successfully connected"
       card:
         type: entities
@@ -153,7 +153,7 @@
     - type: conditional
       conditions:
         - condition: state
-          entity: input_text.charger_connection_status
+          entity: sensor.charger_connection_status
           state: "Successfully connected"
         - condition: state
           entity: input_boolean.use_reduced_max_charge_power
@@ -363,10 +363,10 @@
           state: "Direct caldav source"
       card:
         type: markdown
-        entity: input_text.calendar_account_connection_status
+        entity: sensor.calendar_account_connection_status
         content: >-
-          {{ states("input_text.calendar_account_connection_status")}} |
-          {{ (now().timestamp() - states.input_text.calendar_account_connection_status.last_reported.timestamp()) | timestamp_custom('%H:%M:%S', False) }} ago
+          {{ states("sensor.calendar_account_connection_status")}} |
+          {{ (now().timestamp() - states.sensor.calendar_account_connection_status.last_reported.timestamp()) | timestamp_custom('%H:%M:%S', False) }} ago
         card_mod:
           style: |
             ha-card {
@@ -381,7 +381,7 @@
     - type: conditional
       conditions:
         - condition: state
-          entity: input_text.calendar_account_connection_status
+          entity: sensor.calendar_account_connection_status
           state: "Successfully connected"
         - condition: state
           entity: input_select.car_calendar_source
@@ -623,10 +623,10 @@
           }
 
     - type: markdown
-      entity: input_text.fm_connection_status
+      entity: sensor.fm_connection_status
       content: >-
-        {{ states("input_text.fm_connection_status")}} |
-        {{ (now().timestamp() - states.input_text.fm_connection_status.last_reported.timestamp()) | timestamp_custom('%H:%M:%S', False) }} ago
+        {{ states("sensor.fm_connection_status")}} |
+        {{ (now().timestamp() - states.sensor.fm_connection_status.last_reported.timestamp()) | timestamp_custom('%H:%M:%S', False) }} ago
       card_mod:
         style: |
           ha-card {
@@ -640,7 +640,7 @@
     - type: conditional
       conditions:
         - condition: state
-          entity: input_text.fm_connection_status
+          entity: sensor.fm_connection_status
           state: Please select an asset
       card:
         type: entities

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
@@ -243,88 +243,185 @@ input_number:
     mode: box
     unit_of_measurement: "hrs"
 
-  # Used in both UI and in code.
-  car_state_of_charge:
-    name: SoC history
-    icon: mdi:battery-medium
-    min: 0.0
-    max: 100.0
-    unit_of_measurement: "%"
-    step: 1.0
-    mode: slider
 
-  # Used in both UI and in code.
-  car_remaining_range:
-    name: Car Remaining Range
-    icon: mdi:ev-station
-    min: 0
-    max: 1000
-    unit_of_measurement: "km"
-    step: 100
-    mode: box
+sensor:
+  - platform: template
+    # The platform: number would have been more suitable but HA does not support that
+    # The platform: template is not a prefect match but the only thing that could be hacked
+    # Other properties like state_class: measurement, native_value: int are not allowed
+    # for a template sensor and set via python.
+    sensors:
+      car_state_of_charge:
+        friendly_name: Car state of charge
+        device_class: battery
+        unit_of_measurement: "%"
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  total_charging_cost_last_7_days:
-    name: Total charging costs last 7 days
-    max: 1000.00
-    min: -1000.00
-    step: 0.01
-    unit_of_measurement: "€"
-    mode: box
+      charger_real_charging_power:
+        friendly_name: Charger real charging power
+        device_class: power
+        unit_of_measurement: W
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  total_charged_energy_last_7_days:
-    name: Total charged energy last 7 days
-    max: 10000
-    min: -10000
-    step: 1
-    unit_of_measurement: "kWh"
-    mode: box
+      # Intended for checks to see if the actual power matches this setting
+      current_scheduled_charging_power:
+        friendly_name: Current scheduled charging power
+        device_class: power
+        unit_of_measurement: W
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  total_discharged_energy_last_7_days:
-    name: Total discharged energy last 7 days
-    max: 10000
-    min: -10000
-    step: 1
-    unit_of_measurement: "kWh"
-    mode: box
+      car_remaining_range:
+        friendly_name: Car Remaining Range
+        device_class: distance
+        unit_of_measurement: km
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  net_energy_last_7_days:
-    name: Total net energy last 7 days
-    max: 10000
-    min: -10000
-    step: 1
-    unit_of_measurement: "kWh"
-    mode: box
+      # Used for stats in UI.
+      total_charging_cost_last_7_days:
+        friendly_name: Total charging costs last 7 days
+        device_class: monetary
+        unit_of_measurement: €
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  total_saved_emissions_last_7_days:
-    name: Total saved emissions last 7 days
-    max: 1000
-    min: -1000
-    step: 0.001
-    unit_of_measurement: "kg CO2"
-    mode: box
+      total_charged_energy_last_7_days:
+        friendly_name: Total charged energy last 7 days
+        device_class: energy_storage
+        unit_of_measurement: "kWh"
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  total_emissions_last_7_days:
-    name: Total emissions last 7 days
-    max: 1000
-    min: -1000
-    step: 0.001
-    unit_of_measurement: "kg CO2"
-    mode: box
+      total_discharged_energy_last_7_days:
+        friendly_name: Total discharged energy last 7 days
+        device_class: energy_storage
+        unit_of_measurement: "kWh"
+        value_template: "{{ 0 }}"  # Dummy
 
-  # Used for stats in UI.
-  net_emissions_last_7_days:
-    name: Net emissions last 7 days
-    max: 1000
-    min: -1000
-    step: 0.001
-    unit_of_measurement: "kg CO2"
-    mode: box
+      net_energy_last_7_days:
+        friendly_name: Total net energy last 7 days
+        device_class: energy_storage
+        unit_of_measurement: "kWh"
+        value_template: "{{ 0 }}"  # Dummy
+
+      total_saved_emissions_last_7_days:
+        friendly_name: Total saved emissions last 7 days
+        device_class: weight
+        unit_of_measurement: kg  # CO2 that is...
+        value_template: "{{ 0 }}"  # Dummy
+
+      total_emissions_last_7_days:
+        friendly_name: Total emissions last 7 days
+        device_class: weight
+        unit_of_measurement: kg  # CO2 that is...
+        value_template: "{{ 0 }}"  # Dummy
+
+      net_emissions_last_7_days:
+        friendly_name: Net emissions last 7 days
+        device_class: weight
+        unit_of_measurement: kg  # CO2 that is...
+        value_template: "{{ 0 }}"  # Dummy
+
+      total_discharge_time_last_7_days:
+        friendly_name: Total discharge time in last 7 days
+        value_template: ""
+
+      total_charge_time_last_7_days:
+        friendly_name: Total charge time in last 7 days
+        value_template: ""
+
+      calendar_account_connection_status:
+        friendly_name: Calendar account connection status
+        value_template: ""
+
+      # Used to show a user understandable version of the states in the UI.
+      # E.g. "Charging", "No car connected", etc.
+      charger_state_text:
+        friendly_name: Charger state
+        value_template: ""
+
+      charger_state_int:
+        friendly_name: Charger state int value
+        value_template: "{{ 0 }}"  # Dummy
+
+      charger_connection_status:
+        friendly_name: Calendar account connection status
+        value_template: ""
+
+      poll_refresh_indicator:
+        friendly_name: This changes every time the EVSE gets polled (if active, 5 to 15 sec.)
+        value_template: " "
+
+      # Util entity that holds the events to show in UI in an attribute 'events'
+      calendar_events:
+        value_template: ""
+
+      # This is not a setting but is read from the charger and is
+      # an upper limit for max_(dis-)charging_power
+      charger_max_available_power:
+        value_template: "??"
+
+      fm_connection_status:
+        friendly_name: FlexMeasures connection status
+        value_template: ""
+
+      # Helper for setting text in dashboard.
+      utility_display_name:
+        friendly_name: Utility display name
+        value_template: ""
+
+      # Helper, for setting text in dashboard.
+      optimisation_mode:
+        friendly_name: Optimisation mode
+        value_template: ""
+
+      # Used to store the (serialised) charge schedule HA receives from the
+      # backend FM, not used in UI.
+      charge_schedule:
+        friendly_name: Charge schedule chart data
+        value_template: ""
+
+      # Used to store the (serialized) list of dynamic consumption prices that is fetched by
+      # get_fm_data code from FM. This then is shown in the UI in the graph.
+      consumption_prices:
+        friendly_name: Buy price chart data
+        value_template: ""
+
+      # Used to store the (serialized) list of dynamic consumption prices that is fetched by
+      # get_fm_data code from FM. This then is shown in the UI in the graph.
+      production_prices:
+        friendly_name: Sell price chart data
+        value_template: ""
+
+      # Used to store the (serialized) list of hourly CO2 emissions that is fetched by
+      # get_fm_data code from FM daily. This then is shown in the UI in the graph.
+      co2_emissions:
+        friendly_name: Emissions chart data
+        value_template: ""
+
+      # Based on the current SoC and the schedule a prognosis (list of values) is
+      # calculated and this (serialised list) is stored in this variable. This is Used
+      # in the graph, shown as yellow prognosis line.
+      soc_prognosis:
+        friendly_name: SoC schedule chart data
+        value_template: ""
+
+      # Based on the current SoC and max boost function (when SoC is below minimum).
+      # This contains two values current SoC and min. SoC at expected time.
+      # This is shown in the graph as a red prognosis line.
+      soc_prognosis_boost:
+        friendly_name: SoC Boost chart data
+        value_template: ""
+
+      # Based on the current SoC and Max Charge Now function (from the Charge Mode buttons).
+      # This contains two values current SoC and 100%. SoC at expected time.
+      # This is shown in the graph as a dashed prognosis line.
+      soc_prognosis_max_charge_now:
+        friendly_name: SoC Max Charge Now chart data
+        value_template: ""
+
+      # Forms bar representing the duration of the calendar item at
+      # the desired %.
+      calender_item_in_chart:
+        friendly_name: Calendar item in chart
+        value_template: ""
 
 input_text:
   #############  calendar related entities #############
@@ -338,33 +435,11 @@ input_text:
     name: Password
     icon: mdi:form-textbox-password
     mode: password
-  calendar_account_connection_status:
-    mode: text
-  # Util entity that holds the events in an attribute events
-  calendar_events:
-    mode: text
 
   #############  charger related entities #############
   charger_host_url:
     name: Charger host URL
     icon: mdi:lan-pending
-  # This is not a setting but is read from the charger and is an upper limit for max_(dis-)charging_power
-  charger_max_available_power:
-    mode: text
-    initial: "??"
-  charger_connection_status:
-    mode: text
-  poll_refresh_indicator:
-    name: This changes every time the EVSE gets polled (if active, 5 to 15 sec.)
-    initial: " "
-  # Used to show a user understandable version of the states in the UI.
-  # "Translation" is done in an automation.
-  charger_state:
-    name: Charger state
-    icon: mdi:ev-station
-    max: 100
-    mode: text
-    min: 0
 
   #############  flexmeasures related entities #############
   fm_account_username:
@@ -377,8 +452,6 @@ input_text:
   fm_host_url:
     icon: mdi:server-network-outline
     name: URL
-  fm_connection_status:
-    mode: text
 
   ###################################################################
   #        self_provided settings related to au_amber_electric      #
@@ -414,104 +487,6 @@ input_text:
     min: 1
     max: 1
 
-  #############  UI statistics related entities #############
-  total_discharge_time_last_7_days:
-    name: Total discharge time in last 7 days
-  total_charge_time_last_7_days:
-    name: Total charge time in last 7 days
-
-  # Helper, set by V2G Liberty.py based upon setting utility in secrets.
-  # Used only for setting text in dashboard.
-  utility_display_name:
-    name: Utility display name
-    icon: mdi:transmission-tower
-    max: 100
-    mode: text
-    min: 0
-
-  # Helper, set by V2G Liberty.py based upon setting fm_optimisation_mode in secrets.
-  # Used only for setting text in dashboard.
-  optimisation_mode:
-    name: Optimisation mode
-    icon: mdi:cog-transfer-outline
-    max: 100
-    mode: text
-    min: 0
-
-  # Used to store the (serialised) charge schedule HA receives from the
-  # backend FM, not used in UI.
-  chargeschedule:
-    name: ChargeSchedule
-    max: 10000
-    min: 0
-    mode: text
-    icon: mdi:calendar-multiselect
-
-  # Used to store the (serialized) list of dynamic consumption prices that is fetched by
-  # get_fm_data code from FM. This then is shown in the UI in the graph.
-  consumption_prices:
-    name: Buy price
-    max: 10000
-    min: 0
-    mode: text
-
-  # Used to store the (serialized) list of dynamic consumption prices that is fetched by
-  # get_fm_data code from FM. This then is shown in the UI in the graph.
-  production_prices:
-    name: Sell price
-    max: 10000
-    min: 0
-    mode: text
-
-  # Used to store the (serialized) list of hourly CO2 emissions that is fetched by
-  # get_fm_data code from FM daily. This then is shown in the UI in the graph.
-  co2_emissions:
-    name: Emissions
-    max: 10000
-    min: 0
-    mode: text
-
-  # Based on the current SoC and the schedule a prognosis (list of values) is
-  # calculated and this (serialised list) is stored in this variable. This is Used
-  # in the graph, shown as yellow prognosis line.
-  soc_prognosis:
-    name: SoC schedule
-    max: 10000
-    mode: text
-    min: 0
-
-  # Based on the current SoC and max boost function (when SoC is below minimum).
-  # This contains two values current SoC and min. SoC at expected time.
-  # This is shown in the graph as a red prognosis line.
-  soc_prognosis_boost:
-    name: SoC Boost
-    max: 10000
-    mode: text
-    min: 0
-
-  # Based on the current SoC and Max Charge Now function (from the Charge Mode buttons).
-  # This contains two values current SoC and 100%. SoC at expected time.
-  # This is shown in the graph as a dashed prognosis line.
-  soc_prognosis_max_charge_now:
-    name: SoC Max Charge Now
-    max: 10000
-    mode: text
-    min: 0
-
-  # Forms bar representing the duration of the calendar item at
-  # the desired %.
-  calender_item_in_chart:
-    name: Calendar item in chart
-    max: 10000
-    mode: text
-    min: 0
-
-  # Used for setting an error in the UI when V2G Liberty app cannot retrieve EPEX data.
-  epex_log:
-    name: epex_log
-    max: 10000
-    min: 0
-    mode: text
 
 script:
   restart_ha:

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_package.yaml
@@ -255,69 +255,69 @@ sensor:
         friendly_name: Car state of charge
         device_class: battery
         unit_of_measurement: "%"
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       charger_real_charging_power:
         friendly_name: Charger real charging power
         device_class: power
         unit_of_measurement: W
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       # Intended for checks to see if the actual power matches this setting
       current_scheduled_charging_power:
         friendly_name: Current scheduled charging power
         device_class: power
         unit_of_measurement: W
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       car_remaining_range:
         friendly_name: Car Remaining Range
         device_class: distance
         unit_of_measurement: km
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       # Used for stats in UI.
       total_charging_cost_last_7_days:
         friendly_name: Total charging costs last 7 days
         device_class: monetary
         unit_of_measurement: €
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       total_charged_energy_last_7_days:
         friendly_name: Total charged energy last 7 days
         device_class: energy_storage
-        unit_of_measurement: "kWh"
-        value_template: "{{ 0 }}"  # Dummy
+        unit_of_measurement: kWh
+        value_template: "{{ None }}"  # Dummy
 
       total_discharged_energy_last_7_days:
         friendly_name: Total discharged energy last 7 days
         device_class: energy_storage
-        unit_of_measurement: "kWh"
-        value_template: "{{ 0 }}"  # Dummy
+        unit_of_measurement: kWh
+        value_template: "{{ None }}"  # Dummy
 
       net_energy_last_7_days:
         friendly_name: Total net energy last 7 days
         device_class: energy_storage
-        unit_of_measurement: "kWh"
-        value_template: "{{ 0 }}"  # Dummy
+        unit_of_measurement: kWh
+        value_template: "{{ None }}"  # Dummy
 
       total_saved_emissions_last_7_days:
         friendly_name: Total saved emissions last 7 days
         device_class: weight
         unit_of_measurement: kg  # CO2 that is...
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       total_emissions_last_7_days:
         friendly_name: Total emissions last 7 days
         device_class: weight
         unit_of_measurement: kg  # CO2 that is...
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       net_emissions_last_7_days:
         friendly_name: Net emissions last 7 days
         device_class: weight
         unit_of_measurement: kg  # CO2 that is...
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       total_discharge_time_last_7_days:
         friendly_name: Total discharge time in last 7 days
@@ -339,7 +339,7 @@ sensor:
 
       charger_state_int:
         friendly_name: Charger state int value
-        value_template: "{{ 0 }}"  # Dummy
+        value_template: "{{ None }}"  # Dummy
 
       charger_connection_status:
         friendly_name: Calendar account connection status

--- a/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_ui_module_stats.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/v2g_liberty/v2g_liberty_ui_module_stats.yaml
@@ -1,8 +1,8 @@
 <h3>Last 7 days (approximations)</h3><h4>Costs
-{% if float(states("input_number.net_energy_last_7_days")) == 0 %}
+{% if float(states("sensor.net_energy_last_7_days")) == 0 %}
 € -,--
 {% else %}
-{{ '€ %.2f'|format(float(states("input_number.total_charging_cost_last_7_days"))/float(states("input_number.net_energy_last_7_days"))) }}
+{{ '€ %.2f'|format(float(states("sensor.total_charging_cost_last_7_days"))/float(states("sensor.net_energy_last_7_days"))) }}
 {% endif %}/kWh</h4>
 <table><thead>
 <tr>
@@ -13,18 +13,18 @@
 </tr></thead>
 <tbody><tr>
 <th>Charge</th>
-<th>{{states("input_text.total_charge_time_last_7_days")}}</th>
-<td>{{ '%.1f'|format((states("input_number.total_emissions_last_7_days")) | round(1)) }}</td>
-<td>{{ (states("input_number.total_charged_energy_last_7_days")) | int }}</td>
+<th>{{states("sensor.total_charge_time_last_7_days")}}</th>
+<td>{{ '%.1f'|format((states("sensor.total_emissions_last_7_days")) | round(1)) }}</td>
+<td>{{ (states("sensor.total_charged_energy_last_7_days")) | int }}</td>
 </tr><tr>
 <th>Discharge</th>
-<th>{{states("input_text.total_discharge_time_last_7_days")}}</th>
-<td>{{ '%.1f'|format((states("input_number.total_saved_emissions_last_7_days")) | round(1)) }}</td>
-<td>{{ (states("input_number.total_discharged_energy_last_7_days")) | int }}</td>
+<th>{{states("sensor.total_discharge_time_last_7_days")}}</th>
+<td>{{ '%.1f'|format((states("sensor.total_saved_emissions_last_7_days")) | round(1)) }}</td>
+<td>{{ (states("sensor.total_discharged_energy_last_7_days")) | int }}</td>
 </tr></tbody>
 <tfoot><tr>
 <th>Net results</th>
 <th></th>
-<td>{{ '%.1f'|format((states("input_number.net_emissions_last_7_days")) | round(1)) }}</td>
-<td>{{ (states("input_number.net_energy_last_7_days")) | int }}</td>
+<td>{{ '%.1f'|format((states("sensor.net_emissions_last_7_days")) | round(1)) }}</td>
+<td>{{ (states("sensor.net_energy_last_7_days")) | int }}</td>
 </tr></tfoot></table>


### PR DESCRIPTION
Done by adding the `car_state_of_charge`, `charger_real_charging_power`,  `car_remaining_range` sensors (and others) to the `v2g_liberty_package.yaml`. These were previously created by writing to it from AppDaemon and as such not known to HA and thus not in the history.

Remaining problems:
- All sensor entities have to be derived from a template (enforced by HA) and as they are populated by AppDaemon they don't have a relevant value_template, so a dummy of 0 is used. This results in a (brief) 0 value after restarts. It would be nice if this could be fixed later.
- O.a. the attribute `state_class: measurement` of the sensors cannot be used as it is a template.
- The attributes are not preserved as the set_state() calls overwrite attributes. 
A way to fix these problems might be to use mqtt.

Refactored several input_text and input_number entities to sensors so that (most) input_x entities are only used for actual user input. Renamed to `charger_charger_state` to `charger_state_int`, `charger_state` to `charger_state_text` and `charger_connected_car_state_of_charge` to `car_state_of_charge` for clarity and readability.

Also added a new sensor `current_scheduled_charging_power` that reflects the power that is currently requested by the schedule from the charger. This can help detecting a failing charger.