### PR TITLE
Decouple v2g_liberty from reservations_client

### DIFF
--- a/v2g-liberty/requirements.txt
+++ b/v2g-liberty/requirements.txt
@@ -3,6 +3,7 @@ isodate==0.6.1
 pymodbus==3.8.3
 caldav==1.4.0
 flexmeasures-client==0.2.4
+pyee==12.1.1
 
 # Work around for https://github.com/hassio-addons/addon-appdaemon/issues/345
 numpy<2

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
@@ -421,6 +421,9 @@ class ModbusEVSEclient:
         """To be called when charge_mode in UI is (switched to) Stop
         Do not cancel polling, the information is still relevant.
         """
+        if self.client is None:
+            self.__log("Client not initialised, aborting", level="WARNING")
+            return
         self.__log("made inactive")
         await self.stop_charging()
         await self.__set_charger_control("give")

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
@@ -285,7 +285,7 @@ class ReservationsClient(AsyncIOEventEmitter):
         It is expected that this method is called when the first upcoming calendar item changes
         """
         self.__log("Called from listener")
-        self.__poll_calendar_integration()
+        await self.__poll_calendar_integration()
 
     async def __poll_calendar_integration(
         self, entity=None, attribute=None, old=None, new=None, kwargs=None

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
@@ -31,6 +31,7 @@ class ReservationsClient(AsyncIOEventEmitter):
     hass: ServiceResponseApp = None
 
     def __init__(self, hass: Hass):
+        super().__init__()
         self.hass = hass
         self.__log = log_wrapper.get_class_method_logger(hass.log)
 
@@ -87,7 +88,6 @@ class ReservationsClient(AsyncIOEventEmitter):
         except Exception as e:
             self.__log(f"Unknown error: '{e}'.", level="WARNING")
             return "Unknown error"
-
 
     async def initialise_calendar(self):
         """Called by globals when:

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
@@ -506,7 +506,7 @@ class ReservationsClient(AsyncIOEventEmitter):
             await self.wait_for_complete()
         except Exception as e:
             self.__log(
-                f"Could not call v2g_main_app.handle_calendar_change. Exception: {e}."
+                f"Problem calendar_change event. Exception: {e}."
             )
 
     def __add_target_soc(self, v2g_event: dict) -> dict:

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
@@ -36,8 +36,6 @@ class V2GLibertyApp(ServiceResponseApp):
 
         fm_client.v2g_main_app = v2g_liberty
 
-        reservations_client.v2g_main_app = v2g_liberty
-
         v2g_liberty.evse_client_app = modbus_evse_client
         v2g_liberty.fm_client_app = fm_client
         v2g_liberty.reservations_client = reservations_client

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -4,7 +4,6 @@ import math
 from appdaemon.plugins.hass.hassapi import Hass
 import constants as c
 import log_wrapper
-from service_response_app import ServiceResponseApp
 from settings_manager import SettingsManager
 
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_liberty.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_liberty.py
@@ -137,7 +137,9 @@ class V2Gliberty:
         self.notification_timer_handle = None
         self.no_schedule_notification_is_planned = False
 
-        self.reservations_client.add_listener("calendar_change", self.handle_calendar_change)
+        self.reservations_client.add_listener(
+            "calendar_change", self.handle_calendar_change
+        )
 
         await self.hass.listen_event(self.__pong, "ping")
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_liberty.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_liberty.py
@@ -137,6 +137,8 @@ class V2Gliberty:
         self.notification_timer_handle = None
         self.no_schedule_notification_is_planned = False
 
+        self.reservations_client.add_listener("calendar_change", self.handle_calendar_change)
+
         await self.hass.listen_event(self.__pong, "ping")
 
         await self.hass.listen_state(


### PR DESCRIPTION
This PR introduces pyee "events" to communicate calendar event changes to the V2G Liberty main app.
In this way, the ReservationsClient no longer needs to "know" about V2GLiberty.