### PR TITLE
Decouple v2g_liberty from fm_client

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -1,14 +1,15 @@
 from datetime import datetime, timedelta
+from pyee.asyncio import AsyncIOEventEmitter
 import isodate
 import math
 import constants as c
 import log_wrapper
-from .v2g_globals import time_round, get_local_now
-from .time_slot_util import generate_time_slots
+from v2g_globals import time_round, get_local_now
+from time_slot_util import generate_time_slots
 from appdaemon.plugins.hass.hassapi import Hass
 
 
-class FMClient:
+class FMClient(AsyncIOEventEmitter):
     """This class manages the communication with the FlexMeasures platform, which delivers the
     charging schedules.
     - Saves charging schedule locally (sensor.charge_schedule)
@@ -48,6 +49,7 @@ class FMClient:
     client: object  # Should be FlexMeasuresClient but (early) import statement gives errors..
 
     def __init__(self, hass: Hass):
+        super().__init__()
         self.hass = hass
         self.__log = log_wrapper.get_class_method_logger(hass.log)
 
@@ -672,17 +674,20 @@ class FMClient:
                 level="WARNING",
             )
             self.fm_busy_getting_schedule = False
-            await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", True)
+            self.emit("no_new_schedule", "timeouts_on_schedule", error_state=True)
+            await self.wait_for_complete()
             return
 
         self.fm_busy_getting_schedule = False
 
         if schedule == {}:
             self.__log("schedule is empty")
-            await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", True)
+            self.emit("no_new_schedule", "timeouts_on_schedule", error_state=True)
+            await self.wait_for_complete()
             return
 
-        await self.v2g_main_app.handle_no_new_schedule("timeouts_on_schedule", False)
+        self.emit("no_new_schedule", "timeouts_on_schedule", error_state=False)
+        await self.wait_for_complete()
         self.fm_date_time_last_schedule = get_local_now()
         self.__log(f"schedule: {schedule}")
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
@@ -34,8 +34,6 @@ class V2GLibertyApp(ServiceResponseApp):
         modbus_evse_client.v2g_main_app = v2g_liberty
         modbus_evse_client.v2g_globals = v2g_globals
 
-        fm_client.v2g_main_app = v2g_liberty
-
         reservations_client.v2g_main_app = v2g_liberty
 
         v2g_liberty.evse_client_app = modbus_evse_client

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_liberty.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_liberty.py
@@ -137,6 +137,8 @@ class V2Gliberty:
         self.notification_timer_handle = None
         self.no_schedule_notification_is_planned = False
 
+        self.fm_client_app.add_listener("no_new_schedule", self.handle_no_new_schedule)
+
         await self.hass.listen_event(self.__pong, "ping")
 
         await self.hass.listen_state(


### PR DESCRIPTION
This PR introduces pyee "events" to communicate scheduler changes to the V2G Liberty main app.
In this way, the FmClient no longer needs to "know" about V2GLiberty.