### PR TITLE
250 bug too often no new schedules

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -5,16 +5,22 @@
 ### Fixed
 
 - 🪲 BUG: When boosting for min-soc and this is reached, software hangs, no new schedule is requested. (#247)
+- 🪲 BUG: Too often "No new schedules" (#250)
 
 ### Added
 
-- Feature Request: Loadbalancer function (Unnumbered)
+- 🚀 Feature Request: Loadbalancer function (Unnumbered)
+- 🚀 Feature Request: 'Discarge now' button. (#240)
 
 ### Changed
 
-- Feature Request: Make default % for calendar item the schedule upper limit setting (#244)
+- 🚀 Feature Request: Make default % for calendar item the schedule upper limit setting (#244)
   This includes the option to set a target in km.
 - ⬆️ Bump PyModbus library to v3.8.5
+
+&nbsp;
+
+---
 
 ### [Unreleased]
 
@@ -22,7 +28,6 @@ The next release might include:
 
 #### Adding
 
-- Manual dis-charge function
 - Support for uni-directional charging
 
 #### Changing

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,6 +3,24 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
+## 0.6.0 2025-03-??
+
+### Fixed
+
+- 🪲 BUG: When boosting for min-soc and this is reached, software hangs, no new schedule is requested. (#247)
+- 🪲 BUG: Too often "No new schedules" (#250)
+
+### Added
+
+- 🚀 Feature Request: Loadbalancer function (Unnumbered)
+- 🚀 Feature Request: 'Discarge now' button. (#240)
+
+### Changed
+
+- 🚀 Feature Request: Make default % for calendar item the schedule upper limit setting (#244)
+  This includes the option to set a target in km.
+- ⬆️ Bump PyModbus library to v3.8.5
+
 ## 0.5.3 2025-03-06
 
 ### Fixed

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -315,6 +315,14 @@ class FMClient(AsyncIOEventEmitter):
         """
         self.__log("called.")
         now = get_local_now()
+        if self.client is None:
+            # We are assuming this is a temporary situation and will be resolved soon,
+            # not notifying the user.
+            self.__log(
+                "Abort getting schedule, client not initialised (yet).", level="WARNING"
+            )
+            return
+
         if self.fm_busy_getting_schedule:
             self.__log(
                 f"busy with prior request since: {self.fm_date_time_last_schedule.isoformat()}."

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -877,11 +877,11 @@ class V2GLibertyGlobals:
             setting_object=self.SETTING_CAR_MAX_CAPACITY_IN_KWH,
         )
 
-        c.CAR_MIN_SOC_IN_KWH = (
-            c.CAR_MAX_CAPACITY_IN_KWH * c.CAR_MIN_SOC_IN_PERCENT / 100
-        )
         c.CAR_MIN_SOC_IN_PERCENT = await self.__process_setting(
             setting_object=self.SETTING_CAR_MIN_SOC_IN_PERCENT,
+        )
+        c.CAR_MIN_SOC_IN_KWH = (
+            c.CAR_MAX_CAPACITY_IN_KWH * c.CAR_MIN_SOC_IN_PERCENT / 100
         )
         c.CAR_MAX_SOC_IN_PERCENT = await self.__process_setting(
             setting_object=self.SETTING_CAR_MAX_SOC_IN_PERCENT,
@@ -1285,7 +1285,7 @@ def convert_to_duration_string(duration_in_minutes: int) -> str:
 def parse_to_int(number_string, default_value: int):
     """Reliably parse a string, float or int to an int. If un-parsable return the default value.
     :param number_string: str, float, int, bool (not dict or list)
-    :param default_value: int that is returned if paring failed.
+    :param default_value: int that is returned if parsing failed.
     :return: parsed int
     """
     try:

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -344,10 +344,10 @@ class V2GLibertyGlobals:
 
         await self.__initialise_charger_settings()
         await self.__initialise_electricity_contract_settings()
-        await self.__initialise_calendar_settings()
         await self.__initialise_general_settings()
         # FlexMeasures settings are influenced by the optimisation_ and general_settings.
         await self.__initialise_fm_client_settings()
+        await self.__initialise_calendar_settings()
 
     async def __initialise_devices(self):
         # List of all the recipients to notify


### PR DESCRIPTION
Two things come together here: the fm_client not initialising correctly and the failing schedules.
Calling get_new_schedule on a not completely initialised fm_client led to a "No new schedule" notification. This has been fixed by changing the order of initialisation (not 100% sure if this now never occurs any more, so a call to client is prevented if not initialised properly yet.

Further more there was a bug in calculating the c.CAR_MIN_SOC_IN_KWH which led to un-feasable schedules.

This is a start as there are probably bug in the consolidate_time_ranges() method in the fm_client. We hope to skip this step as FlexMeasures new version can deal with overlapping time-segments. Unfortunately the FM API currently does not deal well with some edge cases. We hope to test end of next week.