### PR TITLE
Pass the SOC sensor ID in the flex-model so that the soc-schedules get recorded in FlexMeasures

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -653,6 +653,7 @@ class FMClient:
             "roundtrip-efficiency": c.ROUNDTRIP_EFFICIENCY_FACTOR,
             "consumption-capacity": max_consumption_power_ranges,
             "production-capacity": max_production_power_ranges,
+            "state-of-charge": {"sensor": c.FM_ACCOUNT_SOC_SENSOR_ID},
         }
         self.__log(f"flex_model: {flex_model}.")
         schedule = {}


### PR DESCRIPTION
This also means that you should be able to then replay the SOC schedules in the FlexMeasures UI, which will help with understanding schedules and/or debugging flex-models or scheduler implementations.

Please test.