### PR TITLE
Added `power-capacity` to flex_model in `fm_client`. 

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,9 +1,10 @@
 # What's changed?
 
-## 0.6.1 2025-05-??
+## 0.6.1 2025-06-??
 
 ### Fixed
 
+- 🪲 BUG: The max-charge power setting of V2G Liberty is overruled by FM asset setting (#279)
 - 🪲 BUG: Check for max power incorrect (#276)
 - 🪲 BUG: Quickly switching between charge mode automatic and other results in schedule being followed (#260)
 - 🪲 BUG: When connecting during a calendar reservation period, the "target cannot be reached" process kicks in while it should not (#261)

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,10 +3,11 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
-## 0.6.1 2025-05-??
+## 0.6.1 2025-06-??
 
 ### Fixed
 
+- 🪲 BUG: The max-charge power setting of V2G Liberty is overruled by FM asset setting (#279)
 - 🪲 BUG: Check for max power incorrect (#276)
 - 🪲 BUG: Quickly switching between charge mode automatic and other results in schedule being followed (#260)
 - 🪲 BUG: When connecting during a calendar reservation period, the "target cannot be reached" process kicks in while it should not (#261)

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -709,6 +709,7 @@ class FMClient(AsyncIOEventEmitter):
         )
 
         flex_model = {
+            "power-capacity": f"{c.CHARGER_MAX_CHARGE_POWER} W",
             "soc-at-start": current_soc_kwh,
             "soc-unit": "kWh",
             "soc-min": c.CAR_MIN_SOC_IN_KWH,


### PR DESCRIPTION
Needs to be tested with FM setting lower/higher than local setting.