### PR TITLE
Handle power value `unavailable` correctly.

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- 🪲 BUG: Load balancer produces errors in log (#290)
 - 🪲 BUG: The max-charge power setting of V2G Liberty is overruled by FM asset setting (#279)
 - 🪲 BUG: Check for max power incorrect (#276)
 - 🪲 BUG: Quickly switching between charge mode automatic and other results in schedule being followed (#260)

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -7,6 +7,7 @@ That file also contains possible changes that the next release might include.
 
 ### Fixed
 
+- 🪲 BUG: Load balancer produces errors in log (#290)
 - 🪲 BUG: The max-charge power setting of V2G Liberty is overruled by FM asset setting (#279)
 - 🪲 BUG: Check for max power incorrect (#276)
 - 🪲 BUG: Quickly switching between charge mode automatic and other results in schedule being followed (#260)


### PR DESCRIPTION
Use preferred `turn_off` and `turn_on` instead of `set_state` for input_boolean entities.