### PR TITLE
AppDaemon now requiers a token. 

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
@@ -17,6 +17,7 @@ appdaemon:
   plugins:
     HASS:
       type: hass
+      token: !env_var SUPERVISOR_TOKEN
 
 logs:
   main_log:


### PR DESCRIPTION
This can be fetched from the `!env_var SUPERVISOR_TOKEN`.