### PR TITLE
Feature: appdaemon watchdog

### DIFF
--- a/v2g-liberty/config.yaml
+++ b/v2g-liberty/config.yaml
@@ -11,6 +11,9 @@ arch:
 init: false
 homeassistant_api: true
 uart: true
+ports:
+  5050/tcp: 5050
+watchdog: http://[HOST]:[PORT:5050]/aui/index.html#/
 map:
   - addon_config:rw
   - homeassistant_config:rw

--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
@@ -26,7 +26,7 @@ logs:
     filename: /config/logs/appdaemon_error.log
 
 http:
-  url: http://127.0.0.1:5050
+  url: http://0.0.0.0:5050
 admin:
 api:
 hadashboard:


### PR DESCRIPTION
Fixes #341.

Approach: 
- Tell AppDaemon to run UI on external interface instead of local-only interface (127.0.0.1:5050 => 0.0.0.0:5050).
- Expose port 5050 externally on the Docker container.

Together, this makes it possible to use <homeassistant>:5050 to access the AppDaemon UI. For debugging, this may be useful.
However, I did not include this as the `webui:`, because I do not think this is interesting for most users.

- Configure the default AppDaemon dashboard URL as the watchdog URL (http://[HOST]:[PORT:5050]/aui/index.html#/)

I tested this by executing this command `s6-rc -d stop appdaemon` inside the appdaemon docker container to stop the appdaemon service cleanly.

After a few minutes Home Assistant Supervisor reports:
```
2025-12-20 12:38:55.549 WARNING (MainThread) [supervisor.misc.tasks] Watchdog missing application response from local_v2g-liberty
2025-12-20 12:40:55.552 WARNING (MainThread) [supervisor.misc.tasks] Watchdog found a problem with local_v2g-liberty application!
2025-12-20 12:40:55.558 INFO (SyncWorker_5) [supervisor.docker.manager] Stopping addon_local_v2g-liberty application
2025-12-20 12:40:58.797 INFO (SyncWorker_5) [supervisor.docker.manager] Cleaning addon_local_v2g-liberty application
2025-12-20 12:40:59.177 INFO (MainThread) [supervisor.docker.addon] Starting Docker add-on local/amd64-addon-v2g-liberty with version 0.7.1
```
and restarts the V2G-Liberty Add-On.