### PR TITLE
Fix fm data importer initialise

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,23 +1,14 @@
 # What's changed?
 
-## 0.7.3 2026-01-31
+## 0.7.4 2026-02-04
 
 ### Fixed
 
-- 🪲 BUG: Chart shows SoC prediction line even if there is no schedule (#389)
-- 🪲 BUG: Domain exception during Notifier initialisation causing startup failures (#385)
-- 🪲 BUG: Monitoring for error state failed to notify (#369)
-- 🪲 BUG: Calculation of the expected SoC incorrect (#374)
+- PR: Fix fm data importer initialise (#397)
 
 ### Added
 
-- 🚀 FEAT: Be able to use hostname instead of only IP-address for charger host in UI (#380)
-- 🚀 PR: Show price forecasts in chart as dotted line (#392)
-
 ### Changed
-
-- Bumped pymodbus library to 3.11.4 (#373)
-- 🚀 FEAT: loadbalancer instructions for entities inline HA 2026 requierments (#387)
 
 &nbsp;
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,6 +3,16 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
+## 0.7.4 2026-02-04
+
+### Fixed
+
+- PR: Fix fm data importer initialise (#397)
+
+### Added
+
+### Changed
+
 ## 0.7.3 2026-01-31
 
 ### Fixed


### PR DESCRIPTION
Summary of the fix:

The bug was in fm_data_importer.py:240. When using AppDaemon's run_in() with keyword arguments like is_initial_call=True, AppDaemon passes them as a dictionary inside args[0], not as actual Python keyword arguments.

Before:

``` python
async def daily_kickoff_price_data(self, *args, is_initial_call: bool = False):
    # is_initial_call was always False because it was stuck in args[0]
```
After:

``` python
async def daily_kickoff_price_data(self, *args):
    # Extract from AppDaemon's callback dict
    is_initial_call = False
    if args and isinstance(args[0], dict):
        is_initial_call = args[0].get("is_initial_call", False)
```