### PR TITLE
BUG: Fix crash when charge power becomes 'unavailable'

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- 🪲 BUG: Unavailable charge power not handled (#408)
 - 🪲 BUG: Gap in chartlines between fixed and forecast (#403)
 - 🪲 BUG: Fixed failing "no prices" notification (#402)
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -7,6 +7,7 @@ That file also contains possible changes that the next release might include.
 
 ### Fixed
 
+- 🪲 BUG: Unavailable charge power not handled (#408)
 - 🪲 BUG: Gap in chartlines between fixed and forecast (#403)
 - 🪲 BUG: Fixed failing "no prices" notification (#402)
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
@@ -197,8 +197,10 @@ class DataMonitor:
 
             self.current_availability_since = local_now
 
-    async def _process_power_change(self, new_power: int):
+    async def _process_power_change(self, new_power):
         """Keep track of updated power changes within a regular interval."""
+        if not isinstance(new_power, (int, float)):
+            return
         local_now = get_local_now()
         duration = int((local_now - self.current_power_since).total_seconds())
         self.period_power_x_duration += duration * new_power

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
@@ -628,7 +628,10 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
             remaining_range=await self.get_car_remaining_range(),
         )
 
-    async def __handle_charge_power_change(self, new_power: int):
+    async def __handle_charge_power_change(self, new_power):
+        if not isinstance(new_power, (int, float)):
+            self.__log(f"Charge power is not a number: '{new_power}', treating as 0W.")
+            new_power = 0
         self.event_bus.emit_event("charge_power_change", new_power=new_power)
         if abs(new_power - self.requested_charge_power) > 500:
             self.__log(


### PR DESCRIPTION
When the charger enters an unrecoverable error state, the charge power entity is set to "unavailable". This string value was passed to handlers that expect numeric values, causing a TypeError crash in both ModbusEVSEclient.__handle_charge_power_change (string - int arithmetic) and DataMonitor._process_power_change (int * string multiplication).

The handlers now guard against non-numeric values: the power handler treats them as 0W, the data monitor ignores the change.