### PR TITLE
🪲 BUG: Fix crash on partial Modbus response

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,9 +1,10 @@
 # What's changed?
 
-## 0.7.6 2026-02-??
+## 0.7.6 2026-03-??
 
 ### Fixed
 
+- 🪲 BUG: Fix crash on partial Modbus response (#409)
 - 🪲 BUG: Unavailable charge power not handled (#408)
 - 🪲 BUG: Gap in chartlines between fixed and forecast (#403)
 - 🪲 BUG: Fixed failing "no prices" notification (#402)
@@ -12,7 +13,7 @@
 
 ### Changed
 
-- 🛠️ Refactoring: Made storing settings more robust (#406) 
+- 🛠️ Refactoring: Made storing settings more robust (#406)
 
 &nbsp;
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,10 +3,11 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
-## 0.7.6 2026-02-??
+## 0.7.6 2026-03-??
 
 ### Fixed
 
+- 🪲 BUG: Fix crash on partial Modbus response (#409)
 - 🪲 BUG: Unavailable charge power not handled (#408)
 - 🪲 BUG: Gap in chartlines between fixed and forecast (#403)
 - 🪲 BUG: Fixed failing "no prices" notification (#402)
@@ -15,7 +16,7 @@ That file also contains possible changes that the next release might include.
 
 ### Changed
 
-- 🛠️ Refactoring: Made storing settings more robust (#406) 
+- 🛠️ Refactoring: Made storing settings more robust (#406)
 
 ## 0.7.5 2026-02-15
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
@@ -907,6 +907,22 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
             self.__log("results is None, abort processing.", level="WARNING")
             return
 
+        if len(results) < length:
+            self.__log(
+                f"Modbus returned {len(results)} registers, expected {length}. "
+                f"Partial data, aborting processing.",
+                level="WARNING",
+            )
+            is_unrecoverable = await self.__handle_modbus_exception(
+                source="__get_and_process_registers (partial result)"
+            )
+            if is_unrecoverable:
+                await self.__handle_un_recoverable_error(
+                    reason="persistent partial modbus responses",
+                    source="__get_and_process_registers",
+                )
+            return
+
         for entity in entities:
             # TODO: remove entity_name in this method.
             entity_name = entity.get("ha_entity_name", "now_handled_via_events")


### PR DESCRIPTION
Add bounds check in __get_and_process_registers to handle cases where the charger returns fewer registers than expected. Previously this caused an IndexError. Now partial responses are logged and escalated through the existing unrecoverable error handling.