### PR TITLE
BUG: Fix schedule request flooding when previous request is lost

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- 🪲 BUG: Fix schedule request flooding when previous request is lost (#410)
 - 🪲 BUG: Fix crash on partial Modbus response (#409)
 - 🪲 BUG: Unavailable charge power not handled (#408)
 - 🪲 BUG: Gap in chartlines between fixed and forecast (#403)

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -7,6 +7,7 @@ That file also contains possible changes that the next release might include.
 
 ### Fixed
 
+- 🪲 BUG: Fix schedule request flooding when previous request is lost (#410)
 - 🪲 BUG: Fix crash on partial Modbus response (#409)
 - 🪲 BUG: Unavailable charge power not handled (#408)
 - 🪲 BUG: Gap in chartlines between fixed and forecast (#403)

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -401,6 +401,9 @@ class FMClient(AsyncIOEventEmitter):
                     f"({seconds_since_last_schedule} sec.), assuming call got 'lost'. "
                     f"Getting new schedule."
                 )
+                # Reset the timestamp so that subsequent calls during the new
+                # request don't immediately consider it "lost" again.
+                self.fm_date_time_last_schedule = now
             else:
                 self.__log(
                     "Not getting new schedule, still processing previous request."
@@ -754,7 +757,10 @@ class FMClient(AsyncIOEventEmitter):
             "production-capacity": max_production_power_ranges,
         }
 
-        self.__log(f"flex_model: {flex_model}.")
+        flex_model_str = str(flex_model)
+        if len(flex_model_str) > 1500:
+            flex_model_str = flex_model_str[:1500] + "..."
+        self.__log(f"flex_model: {flex_model_str}.")
         schedule = {}
         max_retries = 2
         for attempt in range(max_retries + 1):


### PR DESCRIPTION
When a schedule request was detected as "lost" (taking too long), fm_date_time_last_schedule was not updated. This caused every subsequent call to get_new_schedule (triggered every few seconds by polling) to also consider the new request as "lost", firing 10-15+ concurrent requests to FlexMeasures. This resulted in slow scheduling and the StorageFallbackScheduler being used instead of the optimal one.

Also truncate the flex_model log message to 1500 chars to prevent oversized log entries from being dropped by the logging system.