### PR TITLE
Pass SoC sensor ID in flex-model

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,24 +1,18 @@
 # What's changed?
 
-## 0.8.0 2026-04-09
+## 0.8.1 2026-045-??
 
 ### Fixed
 
-- 🪲 BUG: Fix charge power deviation log flooding (#436)
-- 🪲 BUG: Improve test notification with sound feedback buttons (#434)
-- 🪲 BUG: Fix set next action timer (#429)
-- 🪲 BUG: Fix Android critical notifications not playing alarm sound (#426)
-- 🪲 BUG: Fix DST-related flatline prices by migrating from pytz to zoneinfo (#425)
+-
 
 ### Added
 
-- 🚀 FEAT: Extend insights (#420, #423, #430)
+- 🚀 FEAT: Pass SoC sensor ID in flex-model (#440)
 
-### Changed
+### Chaged
 
-- 🛠️ Refactor: Reduce event bus slow listener log noise (#437)
-- 🛠️ Refactor: centralise async timer API usage (#432)
-- ⬆️ Bump flexmeasures-client from 0.7.0 to 0.8.1 (#422)
+-
 
 #### Removing
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,6 +3,22 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
+## 0.8.1 2026-045-??
+
+### Fixed
+
+-
+
+### Added
+
+- 🚀 FEAT: Pass SoC sensor ID in flex-model (#440)
+
+### Chaged
+
+-
+
+
+
 ## 0.8.0 2026-04-09
 
 ### Fixed

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -765,11 +765,11 @@ class FMClient(AsyncIOEventEmitter):
                             "end": erw,
                         }
                     )
-                self.__log(
-                    f"soc_minima processed - "
-                    f"first_b2ms_reset_moment: {first_b2ms_reset_moment.isoformat()}."
-                )
             # -- End for soc_minimum in soc_minima --
+            self.__log(
+                f"soc_minima processed - "
+                f"first_b2ms_reset_moment: {first_b2ms_reset_moment.isoformat()}."
+            )
         # -- End if targets not None --
 
         # Range where schedule should only discharge. This when the SoC is above the max (80%).

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -913,6 +913,7 @@ class FMClient(AsyncIOEventEmitter):
             "roundtrip-efficiency": c.ROUNDTRIP_EFFICIENCY_FACTOR,
             "consumption-capacity": max_consumption_power_ranges,
             "production-capacity": max_production_power_ranges,
+            "state-of-charge": {"sensor": c.FM_ACCOUNT_SOC_SENSOR_ID},
         }
 
         flex_model_str = str(flex_model)


### PR DESCRIPTION
## Summary
- Pass the SoC sensor ID in the flex-model so FlexMeasures records SoC schedules 
  (enables replay in FM UI for debugging). Based on #255 by @Flix6x.
- Fix duplicate `soc_minima processed` log line that triggered AppDaemon's log 
  deduplication, causing the subsequent `flex_model` log to be suppressed.

## Test plan
- [x] Verified flex_model log appears for every schedule request (previously missing 
  when multiple calendar targets were active)
- [x] Verified no more duplicate `soc_minima processed` log lines

Closes #255
