### PR TITLE
🪲 BUG: Fix orphaned schedule timers overriding charge mode changes

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- 🪲 BUG: Fix orphaned schedule timers overriding charge mode changes (#444)
 - 🪲 BUG: Fix ping card toast not showing after mwc-snackbar to ha-toast migration (#443)
 
 ### Added

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -7,6 +7,7 @@ That file also contains possible changes that the next release might include.
 
 ### Fixed
 
+- 🪲 BUG: Fix orphaned schedule timers overriding charge mode changes (#444)
 - 🪲 BUG: Fix ping card toast not showing after mwc-snackbar to ha-toast migration (#443)
 
 ### Added

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -1109,14 +1109,6 @@ class V2Gliberty:
         self.scheduling_timer_handles = []
         self.__log(f"Canceled all {count} charging timers.")
 
-    async def __reset_charging_timers(self, handles):
-        self.__log(
-            f"__reset_charging_timers: cancel current and set {len(handles)} new charging timers."
-        )
-        # We need to be sure no new timers are added unless the old are removed
-        await self.__cancel_charging_timers()
-        self.scheduling_timer_handles = handles
-
     ######################################################################
     # PRIVATE FUNCTIONS FOR COMPOSING, GETTING AND PROCESSING SCHEDULES  #
     ######################################################################
@@ -1194,6 +1186,9 @@ class V2Gliberty:
 
         self.__log("valid schedule")
 
+        # Cancel previous timers before creating new ones to prevent orphaned timers
+        await self.__cancel_charging_timers()
+
         # Create new scheduling timers, to send a control signal for each value
         handles = []
         now = get_local_now()
@@ -1222,7 +1217,7 @@ class V2Gliberty:
                         "source": str_source,
                     }
                 )
-        await self.__reset_charging_timers(handles)  # This also cancels previous timers
+        self.scheduling_timer_handles = handles
 
         exp_soc_values = list(
             accumulate(


### PR DESCRIPTION
Cancel existing charging timers before creating new ones in __process_schedule to prevent orphaned timers when two schedule responses arrive near-simultaneously. Previously, timers were created first and cancelled after, allowing a race condition where one set of timer handles could be lost while the timers themselves remained live in AppDaemon.

Remove __reset_charging_timers as it is no longer needed.