### PR TITLE
Refactor: make AppDaemon timer-API usage consistently async in main_app

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+- 🛠️ Refactor: make AppDaemon timer-API usage consistently async in main_app (#445)
 - 🛠️ Refactor: Increase FM data send frequency from daily to hourly (#441)
 
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -16,6 +16,7 @@ That file also contains possible changes that the next release might include.
 
 ### Changed
 
+- 🛠️ Refactor: make AppDaemon timer-API usage consistently async in main_app (#445)
 - 🛠️ Refactor: Increase FM data send frequency from daily to hourly (#441)
 
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -3,7 +3,7 @@
 import enum
 from itertools import accumulate
 import math
-from typing import AsyncGenerator, List, Optional
+from typing import List, Optional
 from datetime import datetime, timedelta
 import isodate
 from appdaemon.plugins.hass.hassapi import Hass
@@ -13,7 +13,7 @@ from .event_bus import EventBus
 from .v2g_globals import time_round, he, get_local_now, parse_to_int
 from . import constants as c
 from .log_wrapper import get_class_method_logger
-from .timer_utils import cancel_timer_silent, set_oneshot_timer
+from .timer_utils import cancel_timer_silent, set_at_timer, set_oneshot_timer
 
 
 class ChartLine(enum.Enum):
@@ -72,7 +72,7 @@ class V2Gliberty:
     # Utility variables for preventing a frozen app. Call set_next_action at least every x seconds
     timer_handle_set_next_action: object = None
     call_next_action_at_least_every: int = 15 * 60
-    scheduling_timer_handles: List[AsyncGenerator]
+    scheduling_timer_handles: List[str]
 
     # This is a target datetime at which the SoC that is above the max_soc must return back to or
     # below this value. It is dependent on the user setting for allowed duration above max soc.
@@ -535,26 +535,24 @@ class V2Gliberty:
 
                 # Set a timer for the start of the first reservation
                 if is_first_reservation:
-                    await cancel_timer_silent(
-                        self.hass, self.timer_id_first_reservation_start
-                    )
                     run_at = target_start
                     now = get_local_now()
                     if target_start < now:
                         # A last minute added event, handle immediately, give some slack for
                         # processing time.
                         run_at = now + timedelta(seconds=5)
-                    self.timer_id_first_reservation_start = await self.hass.run_at(
+                    self.timer_id_first_reservation_start = await set_at_timer(
+                        self.hass,
+                        self.timer_id_first_reservation_start,
                         callback=self.__handle_first_reservation_start,
                         start=run_at,
                         v2g_event=car_reservation,
                     )
                     # Assumed is that the end will never be in the past as teh v2g_event then will
                     # not be in the list of v2g_events (any more).
-                    await cancel_timer_silent(
-                        self.hass, self.timer_id_first_reservation_end
-                    )
-                    self.timer_id_first_reservation_end = await self.hass.run_at(
+                    self.timer_id_first_reservation_end = await set_at_timer(
+                        self.hass,
+                        self.timer_id_first_reservation_end,
                         callback=self.__handle_first_reservation_end,
                         start=target_end,
                     )
@@ -1055,13 +1053,17 @@ class V2Gliberty:
             await self.hass.set_state(
                 "input_boolean.error_no_new_schedule_available", state="off"
             )
-            canceled_before_run = await self.hass.cancel_timer(
-                self.notification_timer_handle, True
-            )
-            self.__log(
-                f"notification timer cancelled before run: {canceled_before_run}."
-            )
-            if self.no_schedule_notification_is_planned and not canceled_before_run:
+            timer_was_running = False
+            if self.notification_timer_handle:
+                try:
+                    timer_was_running = await self.hass.timer_running(
+                        self.notification_timer_handle
+                    )
+                except Exception:  # pylint: disable=broad-exception-caught
+                    timer_was_running = False
+            await cancel_timer_silent(self.hass, self.notification_timer_handle)
+            self.__log(f"notification timer cancelled before run: {timer_was_running}.")
+            if self.no_schedule_notification_is_planned and not timer_was_running:
                 # Only send this message if "no_schedule_notification" was actually sent
                 title = "Schedules available again"
                 message = (

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/timer_utils.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/timer_utils.py
@@ -67,6 +67,33 @@ async def set_oneshot_timer(
     return await hass.run_in(callback, delay=delay, **kwargs)
 
 
+async def set_at_timer(
+    hass,
+    current_handle: Optional[str],
+    callback: Callable[..., Awaitable[Any]],
+    start: Any,
+    **kwargs: Any,
+) -> str:
+    """Schedule a timer at a specific datetime, cancelling any previous handle first.
+
+    Returns the new (real) timer handle. Use this instead of the
+    ``if handle: cancel; handle = run_at(...)`` pattern so the timer
+    bookkeeping cannot leak coroutines.
+
+    Args:
+        hass: AppDaemon Hass instance with the async timer API.
+        current_handle: Existing timer handle to cancel first, or ``None``
+            / empty string on the first call.
+        callback: Async callable that AppDaemon will invoke at ``start``.
+        start: A ``datetime`` (or anything ``hass.run_at`` accepts) for
+            when the timer should fire.
+        **kwargs: Forwarded to ``hass.run_at`` (and ultimately to the
+            callback as keyword arguments).
+    """
+    await cancel_timer_silent(hass, current_handle)
+    return await hass.run_at(callback, start=start, **kwargs)
+
+
 async def set_recurring_timer(
     hass,
     current_handle: Optional[str],


### PR DESCRIPTION
- Add `set_at_timer` helper to timer_utils.py (cancel-previous + run_at in one call, matching the existing `set_oneshot_timer` pattern)
- Replace the last raw `hass.cancel_timer` call with `timer_running` + `cancel_timer_silent`, guarding against None handles
- Refactor reservation start/end timers to use `set_at_timer`
- Fix type annotation: `List[AsyncGenerator]` → `List[str]` (handles are string UUIDs after await), remove unused AsyncGenerator import