### PR TITLE
Improve CBS fetcher error logging: include response snippet on JSON parse failure

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/reference_price_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/reference_price_fetcher.py
@@ -147,7 +147,8 @@ def _fetch_all_pages(
                         "ERROR",
                     )
                     return []
-                body = json.loads(response.read().decode("utf-8"))
+                raw_body = response.read().decode("utf-8")
+                body = json.loads(raw_body)
         except urllib.error.HTTPError as exc:
             log_fn(f"CBS fetcher: HTTP error {exc.code}: {exc.reason}", "ERROR")
             return []
@@ -155,7 +156,12 @@ def _fetch_all_pages(
             log_fn(f"CBS fetcher: URL error: {exc.reason}", "ERROR")
             return []
         except json.JSONDecodeError as exc:
-            log_fn(f"CBS fetcher: invalid JSON in response: {exc}", "ERROR")
+            snippet = raw_body[:200] if raw_body else "(empty)"
+            log_fn(
+                f"CBS fetcher: invalid JSON in response: {exc}. "
+                f"Response starts with: {snippet}",
+                "ERROR",
+            )
             return []
 
         page_rows = body.get("value", [])


### PR DESCRIPTION
When the CBS OData API returns non-JSON (e.g. an HTML redirect during an outage), the error log now includes the first 200 characters of the response body for easier diagnosis.