### PR TITLE
Migrate to python logging

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changed
 
+- 🛠️ Refactor: Migrate to python logging (#448)
 - 🛠️ Refactor: make AppDaemon timer-API usage consistently async in main_app (#445)
 - 🛠️ Refactor: Increase FM data send frequency from daily to hourly (#441)
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -17,6 +17,7 @@ That file also contains possible changes that the next release might include.
 
 ### Changed
 
+- 🛠️ Refactor: Migrate to python logging (#448)
 - 🛠️ Refactor: make AppDaemon timer-API usage consistently async in main_app (#445)
 - 🛠️ Refactor: Increase FM data send frequency from daily to hourly (#441)
 

--- a/v2g-liberty/docs/developer-events.md
+++ b/v2g-liberty/docs/developer-events.md
@@ -1,0 +1,74 @@
+# Developer events
+
+V2G Liberty exposes several Home Assistant events for debugging and development.
+Fire these from **Developer Tools → Events** in your HA instance.
+
+---
+
+## `v2g_enable_debug_logging`
+
+Temporarily switches the V2G Liberty log level from INFO to DEBUG.
+Useful for diagnosing issues without restarting the app.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `duration_hours` | int | 1 | How long to keep debug logging enabled (max 24) |
+
+**Example event data:**
+```json
+{"duration_hours": 2}
+```
+
+Or fire without data for the default of 1 hour.
+
+**Behaviour:**
+- All V2G Liberty modules immediately start logging at DEBUG level
+- A timer automatically restores INFO level after the specified duration
+- If the app restarts while debug is active, the level resets to INFO (no persistent state)
+- Firing the event again resets the timer to the new duration
+
+---
+
+## `v2g_run_full_repair`
+
+Triggers a full database repair of the `interval_log` table.
+Runs in a background thread (`run_in_executor`) to avoid blocking the app.
+
+**Parameters:** None
+
+**Example:** Fire with empty data `{}`.
+
+**Behaviour:**
+- Repairs SoC gaps, out-of-range values, and energy/power inconsistencies
+- Results are logged (number of repairs, any validation issues)
+- Safe to run while the app is operating — uses its own database connection
+
+---
+
+## `v2g_data_query`
+
+Query aggregated charging data from the local database.
+Results are returned via a `v2g_data_query.result` event.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `start` | string | ISO 8601 timestamp (inclusive) |
+| `end` | string | ISO 8601 timestamp (exclusive) |
+| `granularity` | string | One of: `quarter_hours`, `hours`, `days`, `weeks`, `months`, `years` |
+
+**Example event data:**
+```json
+{
+  "start": "2026-05-01T00:00:00+02:00",
+  "end": "2026-05-12T00:00:00+02:00",
+  "granularity": "days"
+}
+```
+
+**Behaviour:**
+- Fires `v2g_data_query.result` with the aggregated data or an error message
+- Also available as REST endpoint: `GET /api/appdaemon/v2g_data?start=...&end=...&granularity=...`

--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.devcontainer.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.devcontainer.yaml
@@ -28,9 +28,9 @@ appdaemon:
 
 logs:
   main_log:
-    filename: /config/logs/appdaemon_main.log
+    filename: /config/logs/v2g_liberty_main.log
   error_log:
-    filename: /config/logs/appdaemon_error.log
+    filename: /config/logs/v2g_liberty_error.log
 
 http:
   url: http://127.0.0.1:5050

--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
@@ -30,9 +30,9 @@ appdaemon:
 
 logs:
   main_log:
-    filename: /config/logs/appdaemon_main.log
+    filename: /config/logs/v2g_liberty_main.log
   error_log:
-    filename: /config/logs/appdaemon_error.log
+    filename: /config/logs/v2g_liberty_error.log
 
 http:
   url: http://0.0.0.0:5050

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/amber_price_data_manager.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/amber_price_data_manager.py
@@ -64,7 +64,7 @@ class ManageAmberPriceData:
 
     def __init__(self, hass: Hass):
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="amber_price_data_manager")
 
     async def initialize(self):
         self.__log("ManageAmberPriceData.")

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/api_server.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/api_server.py
@@ -1,12 +1,20 @@
 """REST API and HA event interface for aggregated interval data."""
 
+import logging
 from datetime import datetime, timezone
 
 from appdaemon.plugins.hass.hassapi import Hass
 
 from .log_wrapper import get_class_method_logger
+from .timer_utils import set_oneshot_timer
 
 VALID_GRANULARITIES = ("quarter_hours", "hours", "days", "weeks", "months", "years")
+
+# Logger that controls the log level for all v2g-app modules.
+_V2G_LOGGER = logging.getLogger("AppDaemon.v2g-app")
+
+MAX_DEBUG_DURATION_HOURS = 24
+DEFAULT_DEBUG_DURATION_HOURS = 1
 
 
 class ApiServer:
@@ -19,9 +27,10 @@ class ApiServer:
 
     def __init__(self, hass: Hass):
         self.__hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="api_server")
         self.data_store = None
         self.data_repairer = None
+        self._debug_timer_handle = ""
         self.__log("ApiServer created.")
 
     async def initialise(self):
@@ -31,9 +40,12 @@ class ApiServer:
         await self.__hass.listen_event(
             self.__handle_run_full_repair_event, "v2g_run_full_repair"
         )
+        await self.__hass.listen_event(
+            self.__handle_debug_logging_event, "v2g_enable_debug_logging"
+        )
         self.__log(
             "API endpoint and event listeners registered "
-            "(v2g_data_query, v2g_run_full_repair)."
+            "(v2g_data_query, v2g_run_full_repair, v2g_enable_debug_logging)."
         )
 
     async def __handle_run_full_repair_event(self, event_name, data, kwargs):
@@ -52,6 +64,43 @@ class ApiServer:
             return
         self.__log("v2g_run_full_repair event received — starting full repair.")
         await self.data_repairer.run_full_repair_async()
+
+    async def __handle_debug_logging_event(self, event_name, data, kwargs):
+        """Enable debug logging for a limited duration.
+
+        Fire from HA Developer Tools → Events with event type
+        ``v2g_enable_debug_logging``.
+
+        Optional event data:
+            duration_hours (int): How long to keep debug logging enabled.
+                Default: 1, maximum: 24.
+
+        Debug logging is automatically disabled after the specified duration.
+        If the app restarts, the log level resets to INFO (in-memory only).
+        """
+        try:
+            duration = int(data.get("duration_hours", DEFAULT_DEBUG_DURATION_HOURS))
+        except (TypeError, ValueError):
+            duration = DEFAULT_DEBUG_DURATION_HOURS
+        duration = max(1, min(duration, MAX_DEBUG_DURATION_HOURS))
+
+        _V2G_LOGGER.setLevel(logging.DEBUG)
+        self.__log(f"Debug logging enabled for {duration} hour(s).")
+        self.__log(
+            "This DEBUG message confirms debug logging is active.", level="DEBUG"
+        )
+
+        self._debug_timer_handle = await set_oneshot_timer(
+            self.__hass,
+            self._debug_timer_handle,
+            self.__disable_debug_logging,
+            delay=duration * 3600,
+        )
+
+    async def __disable_debug_logging(self, *args):
+        """Timer callback: restore log level to INFO."""
+        _V2G_LOGGER.setLevel(logging.INFO)
+        self.__log("Debug logging disabled (timer expired).")
 
     async def __handle_aggregated_data(self, data, kwargs):
         """Handle requests for aggregated data.

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/base_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/base_fetcher.py
@@ -22,7 +22,7 @@ class BaseFetcher:
         """
         self.hass = hass
         self.fm_client_app = fm_client_app
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="base_fetcher")
 
     def is_client_available(self) -> bool:
         """

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/emission_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/emission_fetcher.py
@@ -31,7 +31,7 @@ class EmissionFetcher(BaseFetcher):
             fm_client_app: FlexMeasures client for API calls
         """
         super().__init__(hass, fm_client_app)
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="emission_fetcher")
 
     async def fetch_emissions(self, now: datetime) -> Optional[Dict[str, any]]:
         """

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/entsoe_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/entsoe_fetcher.py
@@ -42,7 +42,7 @@ class EntsoeFetcher(BaseFetcher):
             fm_client_app: FlexMeasures client for API calls
         """
         super().__init__(hass, fm_client_app)
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="entsoe_fetcher")
 
     async def fetch_latest_dt(self, now: datetime) -> Optional[datetime]:
         """

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/price_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/price_fetcher.py
@@ -31,7 +31,7 @@ class PriceFetcher(BaseFetcher):
             fm_client_app: FlexMeasures client for API calls
         """
         super().__init__(hass, fm_client_app)
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="price_fetcher")
 
     async def fetch_prices(
         self, price_type: str, now: datetime

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
@@ -98,7 +98,7 @@ class DataMonitor:
 
     def __init__(self, hass: Hass, event_bus: EventBus):
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="data_monitor")
         self.event_bus = event_bus
 
     async def initialize(self):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_repairer.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_repairer.py
@@ -75,7 +75,7 @@ class DataRepairer:
 
     def __init__(self, hass: Hass):
         self.__hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="data_repairer")
 
     async def initialise(self):
         """Schedule periodic incremental repair runs.

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_store.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_store.py
@@ -659,7 +659,7 @@ class DataStore:
         self.__connection.commit()
         updated = cursor.rowcount
         cursor.close()
-        self.__log(f"Updated {updated} naive charging row(s).")
+        self.__log(f"Updated {updated} naive charging row(s).", level="DEBUG")
 
     def get_last_naive_soc(self) -> float | None:
         """Return the most recent naive_soc_pct value, or None if unavailable."""

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_store.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_store.py
@@ -273,7 +273,7 @@ class DataStore:
     DB_PATH = "/data/v2g_liberty_data.db"
 
     def __init__(self, hass: Hass):
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="data_store")
         self.__connection: sqlite3.Connection | None = None
         self.__log("DataStore initialised (no DB connection yet).")
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/event_bus.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/event_bus.py
@@ -114,7 +114,7 @@ class EventBus(AsyncIOEventEmitter):
     def __init__(self, hass: Hass):
         super().__init__()
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="event_bus")
         self.__log("EventBus initialized successfully.")
 
     def emit_event(self, event, *args, **kwargs):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -61,7 +61,7 @@ class FMClient(AsyncIOEventEmitter):
     def __init__(self, hass: Hass, event_bus: EventBus):
         super().__init__()
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="fm_client")
 
         self.event_bus = event_bus
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_data_importer.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_data_importer.py
@@ -1,6 +1,5 @@
 """Module for importing price and usage data from FlexMeasures."""
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
@@ -293,12 +292,9 @@ class FlexMeasuresDataImporter:
         )
 
         # Persist combined prices to local DB (upsampled to 5-min resolution).
-        # Runs in executor to avoid blocking the event loop with synchronous
-        # SQLite writes and pandas processing.
         if consumption_ok and production_ok:
             try:
-                loop = asyncio.get_event_loop()
-                await loop.run_in_executor(None, self._persist_epex_prices_to_db)
+                self._persist_epex_prices_to_db()
             except Exception as e:
                 self.__log(
                     f"Failed to persist EPEX prices to DB: {e}",

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_data_importer.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_data_importer.py
@@ -1,5 +1,6 @@
 """Module for importing price and usage data from FlexMeasures."""
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
@@ -98,7 +99,7 @@ class FlexMeasuresDataImporter:
     def __init__(self, hass: Hass, notifier: Notifier):
         self.hass = hass
         self.notifier = notifier
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="fm_data_importer")
 
         # These are variables are used to decide what message to send to the user and can have the
         # following values:
@@ -291,10 +292,13 @@ class FlexMeasuresDataImporter:
             price_type="production", entsoe_latest_dt=entsoe_latest_dt
         )
 
-        # Persist combined prices to local DB (upsampled to 5-min resolution)
+        # Persist combined prices to local DB (upsampled to 5-min resolution).
+        # Runs in executor to avoid blocking the event loop with synchronous
+        # SQLite writes and pandas processing.
         if consumption_ok and production_ok:
             try:
-                self._persist_epex_prices_to_db()
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, self._persist_epex_prices_to_db)
             except Exception as e:
                 self.__log(
                     f"Failed to persist EPEX prices to DB: {e}",

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_data_sender.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_data_sender.py
@@ -23,7 +23,7 @@ class FMDataSender:
 
     def __init__(self, hass: Hass):
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="fm_data_sender")
 
     async def initialize(self):
         """Initialise send status and schedule daily export."""

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/ha_ui_manager.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/ha_ui_manager.py
@@ -21,7 +21,7 @@ class HAUIManager:
         self.hass = hass
         self.event_bus = event_bus
 
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="ha_ui_manager")
 
         self._initialize()
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/log_wrapper.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/log_wrapper.py
@@ -1,26 +1,47 @@
-import inspect
+"""Logging wrapper for V2G Liberty modules.
+
+Provides a log function that automatically includes the module name,
+line number, and function name of the caller in every log message.
+
+Uses Python's standard ``logging`` module instead of AppDaemon's
+``hass.log()`` because:
+- ``logging`` is thread-safe (``hass.log`` crashes in ``run_in_executor``)
+- Runtime log-level switching is possible via ``logger.setLevel()``
+- Per-module log levels are supported
+
+Log output goes to the same file as ``hass.log()`` because AppDaemon
+configures a ``RotatingFileHandler`` on the ``"AppDaemon"`` logger, and
+our child loggers propagate to it automatically.
+
+Caller info (line number, function name) is embedded in the message
+itself because AppDaemon's formatter does not include ``%(lineno)d``
+or ``%(funcName)s``.
+"""
+
+import logging
+import sys
 
 
-def get_class_method_logger(ad_log):
+def get_class_method_logger(module_name=""):
+    """Create a log function for a module.
+
+    Args:
+        module_name: Short module name (e.g. ``"main_app"``), used as the
+            logger child name under ``AppDaemon.v2g-app``.
+
+    Returns:
+        A callable ``log(msg, level="")`` that logs via Python's ``logging``.
+        Each message is prefixed with ``module.lineno > function > ``.
+    """
+    logger = logging.getLogger(f"AppDaemon.v2g-app.{module_name}")
+
     def log(msg: str, level: str = ""):
-        info = inspect.stack()[1][0]
-        the_class = __truncate(info.f_locals["self"].__class__.__name__, 20)
-        the_method = info.f_code.co_name
-        # The current custom is to add the method name to the message, this is not needed any more as
-        # it is added here already. So, if it is in the message, remove it.
-        msg = msg.replace(f"{the_method} ", "")
-        the_method = __truncate(the_method, 20)
-        line_no = info.f_lineno
-        if level == "":
-            level = "INFO"
-        msg = f"{the_class}.{line_no} > {the_method} > {msg}"
-        ad_log(msg=msg, level=level)
-
-    def __truncate(the_string:str, length:int):
-        if len(the_string) > length:
-            length_end = int(length/2)
-            length = length - 1 - length_end
-            the_string = the_string[:length] + "~" + the_string[-length_end:]
-        return the_string
+        log_level = getattr(logging, level.upper() if level else "INFO", logging.INFO)
+        # Get caller info from the frame above (the actual caller).
+        frame = sys._getframe(1)
+        lineno = frame.f_lineno
+        func_name = frame.f_code.co_name
+        formatted = f"{lineno} > {func_name} > {msg}"
+        logger.log(log_level, formatted)
 
     return log

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -109,7 +109,7 @@ class V2Gliberty:
         self.hass = hass
         self.notifier = notifier
         self.event_bus = event_bus
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="main_app")
 
     async def initialize(self):
         self.__log("Initializing V2Gliberty")
@@ -232,13 +232,7 @@ class V2Gliberty:
         - New prices have been detected (Amber only)
         - Every 15 minutes if none of the above
         """
-        # Only for debugging:
-        if v2g_args is not None:
-            source = v2g_args
-        else:
-            source = "unknown"
-        # Silenced to reduce log noise — re-enable when investigating call cadence.
-        # self.__log(f"Set next action called from source: {source}.")
+        self.__log(f"Set next action called from source: {v2g_args}.", level="DEBUG")
 
         # Make sure this function gets called every x minutes to prevent a "frozen" app.
         self.timer_handle_set_next_action = await set_oneshot_timer(
@@ -708,7 +702,9 @@ class V2Gliberty:
             return
 
         half_time_ve = ve_start + (ve_end - ve_start) / 2
-        # self.__log(f"Half-time-ve: {half_time_ve.strftime(time_format)}.")
+        self.__log(
+            f"Half-time-ve: {half_time_ve.strftime(time_format)}.", level="DEBUG"
+        )
         if get_local_now() > half_time_ve:
             # This can be the case if:
             # + a calendar item is added with a start-time in the past.

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -845,7 +845,7 @@ class V2Gliberty:
             await self.hass.set_state(
                 entity, state=new_state, attributes=clear_line_records
             )
-            self.__log(f"chart_line_name '{chart_line_name}' cleared.")
+            self.__log(f"chart_line_name '{chart_line_name}' cleared.", level="DEBUG")
         else:
             # Handle both list format (legacy) and dict format (with optional metadata)
             if isinstance(records, dict) and "records" in records:
@@ -873,7 +873,9 @@ class V2Gliberty:
                     await self.hass.set_state(
                         entity, state=new_state, attributes=clear_line_records
                     )
-                    self.__log(f"chart_line_name '{chart_line}' cleared.")
+                    self.__log(
+                        f"chart_line_name '{chart_line}' cleared.", level="DEBUG"
+                    )
 
     ######################################################################
     #                    PRIVATE CALLBACK FUNCTIONS                      #
@@ -1279,7 +1281,7 @@ class V2Gliberty:
         charge_power = kwargs.get("charge_power", None)
         charge_power_in_watt = parse_to_int(charge_power, None)
         if charge_power_in_watt is None:
-            self.__log("invalid charge_power: None")
+            self.__log("invalid charge_power: None", level="WARNING")
             return
         source = kwargs.get("source", "unknown source")
         self.__log(f"Charger power {charge_power_in_watt}W requested by {source}.")

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
@@ -256,7 +256,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         """
         super().__init__()
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="modbus_evse_client")
 
         self.event_bus = event_bus
 
@@ -479,7 +479,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
     async def is_car_connected(self) -> bool:
         """Indicates if currently a car is connected to the charger."""
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         is_connected = self.client is not None
         is_connected = (
@@ -492,14 +492,14 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
     async def is_charging(self) -> bool:
         """Indicates if currently the connected car is charging (not discharging)"""
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         return await self.__get_charger_state() == self.CHARGING_STATE
 
     async def is_discharging(self) -> bool:
         """Indicates if currently the connected car is discharging (not charging)"""
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         return await self.__get_charger_state() == self.DISCHARGING_STATE
 
@@ -573,7 +573,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
 
         """
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         if take_or_give_control == "take":
             await self.__modbus_write(
@@ -653,7 +653,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
     ):
         self.__log(f"called {new_charger_state=}, {old_charger_state=}.")
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         if (
             new_charger_state in self.ERROR_STATES
@@ -725,7 +725,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         self.__log(f"Called with action '{action}', reason: '{reason}'.")
 
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         action_value = ""
 
@@ -758,7 +758,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
 
     async def __is_charging_or_discharging(self) -> bool:
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         state = await self.__get_charger_state()
         if state is None:
@@ -784,7 +784,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         If the car is disconnected the charger returns 0 representing "unavailable".
         """
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         if not await self.is_car_connected():
             self.__log("no car connected, returning SoC = 'unavailable'")
@@ -876,7 +876,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
 
     async def __get_charger_state(self) -> int:
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         charger_state = self.ENTITY_CHARGER_STATE["current_value"]
         if charger_state is None:
@@ -888,7 +888,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
 
     async def __get_charge_power(self) -> int:
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         state = self.ENTITY_CHARGER_CURRENT_POWER["current_value"]
         if state is None:
@@ -1057,7 +1057,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         """
         self.__log(f"called from {source}, power {charge_power}.")
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active is false, not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         # Make sure that discharging does not occur below minimum SoC.
         if not skip_min_soc_check and charge_power < 0:
@@ -1120,7 +1120,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         When Charge mode is off, is handled by handle_charge_mode
         """
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         if self.try_get_new_soc_in_process:
             # At the end of the process of (forcefully) getting a soc this method is called (again).
@@ -1162,7 +1162,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
             reason (str, optional): For debugging only
         """
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         self.__log(f"reason: {reason}")
         await cancel_timer_silent(self.hass, self.poll_timer_handle)
@@ -1228,7 +1228,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         :return: the read value
         """
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         # Times in seconds
         total_time = 0
@@ -1315,7 +1315,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         """
 
         if not self._am_i_active:
-            pass  # log silenced — was "called while _am_i_active == False. Not blocking."
+            self.__log("Called while inactive, not blocking.", level="DEBUG")
 
         if value < 0:
             # Modbus cannot handle negative values directly.
@@ -1539,7 +1539,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         To be called every time there has been a successful modbus read/write.
         :return: Nothing
         """
-        # self.__log("called")
+        self.__log("called", level="DEBUG")
         if self.modbus_exception_counter == 1:
             self.__log("There was an modbus exception, now solved.")
             await self.v2g_main_app.reset_charger_communication_fault()

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/modbus_evse_client.py
@@ -486,7 +486,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
             is_connected
             and await self.__get_charger_state() not in self.DISCONNECTED_STATES
         )
-        self.__log(f"called, returning: {is_connected}")
+        self.__log(f"is_connected: {is_connected}", level="DEBUG")
         return is_connected
 
     async def is_charging(self) -> bool:
@@ -722,7 +722,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         Returns:
             nothing
         """
-        self.__log(f"Called with action '{action}', reason: '{reason}'.")
+        self.__log(f"Called with action '{action}', reason: '{reason}'.", level="DEBUG")
 
         if not self._am_i_active:
             self.__log("Called while inactive, not blocking.", level="DEBUG")
@@ -753,7 +753,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         await self.__modbus_write(
             address=self.SET_ACTION_REGISTER, value=action_value, source=txt
         )
-        self.__log(f"{txt}{reason}")
+        self.__log(f"{txt}{reason}", level="DEBUG")
         return
 
     async def __is_charging_or_discharging(self) -> bool:
@@ -1055,7 +1055,7 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
             source (str, optional):
               For logging purposes.
         """
-        self.__log(f"called from {source}, power {charge_power}.")
+        self.__log(f"called from {source}, power {charge_power}.", level="DEBUG")
         if not self._am_i_active:
             self.__log("Called while inactive, not blocking.", level="DEBUG")
 
@@ -1092,7 +1092,8 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         if self.requested_charge_power == charge_power:
             self.__log(
                 f"New-charge-power-setting from {source=} is same as "
-                f"current-charge-power-setting: {charge_power} W. Not writing to charger."
+                f"current-charge-power-setting: {charge_power} W. Not writing to charger.",
+                level="DEBUG",
             )
             return
 
@@ -1104,7 +1105,9 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         self.requested_charge_power = charge_power
 
         if not res:
-            self.__log(f"Failed to set charge power to {charge_power} Watt.")
+            self.__log(
+                f"Failed to set charge power to {charge_power} Watt.", level="WARNING"
+            )
             # If negative value result in false, check if grid code is set correct in charger.
         return
 
@@ -1539,7 +1542,6 @@ class ModbusEVSEclient(AsyncIOEventEmitter):
         To be called every time there has been a successful modbus read/write.
         :return: Nothing
         """
-        self.__log("called", level="DEBUG")
         if self.modbus_exception_counter == 1:
             self.__log("There was an modbus exception, now solved.")
             await self.v2g_main_app.reset_charger_communication_fault()

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/monitor_pause_at_reconnect.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/monitor_pause_at_reconnect.py
@@ -28,7 +28,7 @@ class MonitorPauseAtReconnect:
         self.notifier = notifier
         self.event_bus = event_bus
 
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="monitor_pause_at_reconnect")
 
         self.event_bus.add_event_listener(
             "is_car_connected", self._handle_connected_state_change

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/naive_charging_simulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/naive_charging_simulator.py
@@ -43,7 +43,7 @@ class NaiveChargingSimulator:
     def __init__(self, hass: Hass, event_bus: EventBus):
         self.hass = hass
         self.event_bus = event_bus
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="naive_charging_simulator")
 
     async def initialise(self):
         """Subscribe to events and run initial batch in the background."""

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/nissan_leaf_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/nissan_leaf_monitor.py
@@ -32,7 +32,7 @@ class NissanLeafMonitor:
         self.notifier = notifier
         self.event_bus = event_bus
 
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="nissan_leaf_monitor")
 
         self._initialize()
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/notifier_util.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/notifier_util.py
@@ -28,7 +28,7 @@ class Notifier:
 
     def __init__(self, hass: Hass, event_bus: EventBus):
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="notifier_util")
 
         self.event_bus = event_bus
         # not used yet

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/octopus_price_data_manager.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/octopus_price_data_manager.py
@@ -90,7 +90,7 @@ class ManageOctopusPriceData:
 
     def __init__(self, hass: Hass):
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="octopus_price_data_manager")
 
     async def initialize(self):
         self.__log("Initializing")
@@ -247,7 +247,7 @@ class ManageOctopusPriceData:
         consumption_prices = [
             convert_price(price[self.PRICE_LABEL]) for price in reversed(prices)
         ]
-        # self.__log(f"start: {start}, end: {end}, prices: {prices}.")
+        self.__log(f"start: {start}, end: {end}, prices: {prices}.", level="DEBUG")
         if self.fm_client_app is not None:
             res = await self.fm_client_app.post_measurements(
                 sensor_id=c.FM_PRICE_CONSUMPTION_SENSOR_ID,
@@ -322,7 +322,7 @@ class ManageOctopusPriceData:
         production_prices = [
             convert_price(price[self.PRICE_LABEL]) for price in reversed(prices)
         ]
-        # self.__log(f"start: {start}, end: {end}, prices: {prices}.")
+        self.__log(f"start: {start}, end: {end}, prices: {prices}.", level="DEBUG")
 
         if self.fm_client_app is not None:
             res = await self.fm_client_app.post_measurements(

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reference_price_manager.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reference_price_manager.py
@@ -37,7 +37,7 @@ class ReferencePriceManager:
 
     def __init__(self, hass: Hass):
         self.hass = hass
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="reference_price_manager")
 
     async def initialise(self):
         """Schedule daily refresh and kick off initial fetch in the background.
@@ -96,7 +96,10 @@ class ReferencePriceManager:
         end_month = (now.replace(day=1) + timedelta(days=32)).strftime("%Y-%m")
 
         def _log(msg, level="INFO"):
-            self.hass.log(msg, level=level)
+            import logging as _logging
+
+            log_level = getattr(_logging, level.upper(), _logging.INFO)
+            _logging.getLogger("AppDaemon.v2g-app.cbs_fetcher").log(log_level, msg)
 
         loop = asyncio.get_event_loop()
         rows = await loop.run_in_executor(

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
@@ -330,7 +330,7 @@ class ReservationsClient(AsyncIOEventEmitter):
         Ideally the listener would trigger for any change in any future calendar item, then polling
         would not be necessary.
         """
-        self.__log("Called")
+        self.__log("Called", level="DEBUG")
 
         now = get_local_now()
         start = now.isoformat()

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/reservations_client.py
@@ -42,7 +42,7 @@ class ReservationsClient(AsyncIOEventEmitter):
         super().__init__()
         self.hass = hass
         self.event_bus = event_bus
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="reservations_client")
 
         self.principal = None
         self.poll_timer_id = ""

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/settings_manager.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/settings_manager.py
@@ -172,12 +172,15 @@ class SettingsManager:
             entity_id (str): setting name = the full entity_id from HA
             setting_value: the value to set.
         """
-        # self.__log(f"__store_setting, entity_id: '{entity_id}' to value '{value}'.")
+        self.__log(
+            f"__store_setting, entity_id: '{entity_id}' to value '{value}'.",
+            level="DEBUG",
+        )
         self.settings[entity_id] = value
         self.__write_to_file()
 
     def __write_to_file(self):
-        # self.__log(f"__write_to_file, settings: '{self.settings}'.")
+        self.__log(f"__write_to_file, settings: '{self.settings}'.", level="DEBUG")
         # Write to a temporary file first, then atomically replace.
         # This prevents an empty settings file if the process is killed
         # during write (e.g. system reboot, HA restart, power loss).

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -1,6 +1,7 @@
 """Module to initialise settings and CONSTANTS"""
 
 import asyncio
+import logging
 import math
 from datetime import datetime, timedelta
 
@@ -294,7 +295,7 @@ class V2GLibertyGlobals:
     def __init__(self, hass: Hass, notifier: Notifier):
         self.hass = hass
         self.notifier = notifier
-        self.__log = get_class_method_logger(hass.log)
+        self.__log = get_class_method_logger(module_name="v2g_globals")
         self.v2g_settings = SettingsManager(log=self.__log)
 
         # VAT/markup settings for data import (only used for nl_generic provider)
@@ -1473,7 +1474,7 @@ def is_local_now_between(start_time: str, end_time: str, now_time: str = None) -
     end_dt = datetime.combine(today_date, time_obj, tzinfo=c.TZ)
 
     if end_dt < start_dt:
-        # self.__log(f"end_dt < start_dt ...")
+        logging.getLogger("AppDaemon.v2g-app.v2g_globals").debug("end_dt < start_dt")
         # Start and end time backwards, so it spans midnight.
         # Let's start by assuming end_dt is wrong and should be tomorrow.
         # This will be true if we are currently after start_dt

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_api_server.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_api_server.py
@@ -64,12 +64,14 @@ class TestInitialisation:
         await api_server.initialise()
         hass.register_endpoint.assert_called_once()
         assert hass.register_endpoint.call_args[0][1] == "v2g_data"
-        # Two event listeners are registered: data query + on-demand repair.
-        assert hass.listen_event.call_count == 2
-        registered_events = {
-            call.args[1] for call in hass.listen_event.call_args_list
+        # Three event listeners: data query, on-demand repair, debug logging.
+        assert hass.listen_event.call_count == 3
+        registered_events = {call.args[1] for call in hass.listen_event.call_args_list}
+        assert registered_events == {
+            "v2g_data_query",
+            "v2g_run_full_repair",
+            "v2g_enable_debug_logging",
         }
-        assert registered_events == {"v2g_data_query", "v2g_run_full_repair"}
 
     @pytest.mark.asyncio
     async def test_valid_granularities_constant(self):

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_monitor.py
@@ -597,27 +597,19 @@ class TestHandleCalendarChange:
     @pytest.mark.asyncio
     @patch("apps.v2g_liberty.data_monitor.get_local_now", return_value=TEST_NOW)
     async def test_handles_db_exception_gracefully(
-        self, mock_now, monitor, data_store, hass
+        self, mock_now, monitor, data_store, hass, caplog
     ):
         """DB exception should be caught and logged as WARNING."""
+        import logging
+
         data_store.insert_reservation.side_effect = Exception("DB locked")
         event = self._make_event()
 
         # Should not raise
-        await monitor._handle_calendar_change(v2g_events=[event])
+        with caplog.at_level(logging.WARNING):
+            await monitor._handle_calendar_change(v2g_events=[event])
 
-        # Check that a warning was logged (log_wrapper passes msg= and level= as kwargs)
-        warning_logged = False
-        for call in hass.log.call_args_list:
-            kwargs = call.kwargs or {}
-            msg = kwargs.get("msg", "")
-            if (
-                "Failed to write reservation" in msg
-                and kwargs.get("level") == "WARNING"
-            ):
-                warning_logged = True
-                break
-        assert warning_logged
+        assert "Failed to write reservation" in caplog.text
 
 
 # =====================================================================

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_store.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_store.py
@@ -1,5 +1,6 @@
 """Unit test (pytest) for data_store module."""
 
+import logging
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock
 
@@ -22,24 +23,6 @@ from apps.v2g_liberty.data_store import (
 # Fixed timezone for deterministic tests
 TEST_TZ = timezone(timedelta(hours=1))
 TEST_NOW = datetime(2026, 2, 21, 12, 0, 0, tzinfo=TEST_TZ)
-
-
-def get_log_message(log_call):
-    """Extract the log message from a single call object."""
-    if log_call and log_call.args:
-        return log_call.args[0]
-    elif log_call and log_call.kwargs:
-        return log_call.kwargs.get("msg", "")
-    return ""
-
-
-def find_log_containing(hass, text):
-    """Search all log calls for a message containing the given text."""
-    for call in hass.log.call_args_list:
-        msg = get_log_message(call)
-        if text in msg:
-            return call
-    return None
 
 
 @pytest.fixture
@@ -215,14 +198,15 @@ class TestSchemaVersion:
         assert count == 1
 
     @pytest.mark.asyncio
-    async def test_second_start_logs_up_to_date(self, data_store, hass):
+    async def test_second_start_logs_up_to_date(self, data_store, hass, caplog):
         await data_store.initialise()
         data_store.close()
-        await data_store.initialise()
-        assert find_log_containing(hass, "up to date") is not None
+        with caplog.at_level(logging.INFO):
+            await data_store.initialise()
+        assert "up to date" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_newer_version_logs_warning(self, data_store, hass):
+    async def test_newer_version_logs_warning(self, data_store, hass, caplog):
         await data_store.initialise()
         # Manually bump version to simulate a downgrade scenario
         cursor = data_store.connection.cursor()
@@ -234,10 +218,9 @@ class TestSchemaVersion:
         cursor.close()
         # Reinitialise
         data_store.close()
-        await data_store.initialise()
-        warning_call = find_log_containing(hass, "newer than expected")
-        assert warning_call is not None
-        assert warning_call.kwargs.get("level") == "WARNING"
+        with caplog.at_level(logging.WARNING):
+            await data_store.initialise()
+        assert "newer than expected" in caplog.text
 
     @pytest.mark.asyncio
     async def test_tables_preserved_after_reinitialise(self, data_store):
@@ -414,15 +397,16 @@ class TestUpsertPrices:
         assert row["price_rating"] is None
 
     @pytest.mark.asyncio
-    async def test_upsert_prices_logs_count(self, data_store, hass):
+    async def test_upsert_prices_logs_count(self, data_store, hass, caplog):
         await data_store.initialise()
-        data_store.upsert_prices(
-            [
-                ("2026-02-21T12:00:00+01:00", 0.25, 0.10, None),
-                ("2026-02-21T12:05:00+01:00", 0.26, 0.11, None),
-            ]
-        )
-        assert find_log_containing(hass, "2 price row(s)") is not None
+        with caplog.at_level(logging.INFO):
+            data_store.upsert_prices(
+                [
+                    ("2026-02-21T12:00:00+01:00", 0.25, 0.10, None),
+                    ("2026-02-21T12:05:00+01:00", 0.26, 0.11, None),
+                ]
+            )
+        assert "2 price row(s)" in caplog.text
 
 
 class TestInsertReservation:
@@ -734,15 +718,16 @@ class TestUpsertEmissions:
         assert count == 1
 
     @pytest.mark.asyncio
-    async def test_upsert_emissions_logs_count(self, data_store, hass):
+    async def test_upsert_emissions_logs_count(self, data_store, hass, caplog):
         await data_store.initialise()
-        data_store.upsert_emissions(
-            [
-                ("2026-02-21T12:00:00+01:00", 350.5),
-                ("2026-02-21T12:05:00+01:00", 348.2),
-            ]
-        )
-        assert find_log_containing(hass, "2 emission row(s)") is not None
+        with caplog.at_level(logging.INFO):
+            data_store.upsert_emissions(
+                [
+                    ("2026-02-21T12:00:00+01:00", 350.5),
+                    ("2026-02-21T12:05:00+01:00", 348.2),
+                ]
+            )
+        assert "2 emission row(s)" in caplog.text
 
 
 class TestUpsertReferencePrices:
@@ -811,15 +796,16 @@ class TestUpsertReferencePrices:
         assert cursor.fetchone()[0] == 3
 
     @pytest.mark.asyncio
-    async def test_upsert_logs_count(self, data_store, hass):
+    async def test_upsert_logs_count(self, data_store, hass, caplog):
         await data_store.initialise()
-        data_store.upsert_reference_prices(
-            [
-                ("2026-01", 0.10, 0.15, "cbs", "2026-03-01T00:00:00+00:00"),
-                ("2026-02", 0.11, 0.16, "cbs", "2026-03-01T00:00:00+00:00"),
-            ]
-        )
-        assert find_log_containing(hass, "2 reference price row(s)") is not None
+        with caplog.at_level(logging.INFO):
+            data_store.upsert_reference_prices(
+                [
+                    ("2026-01", 0.10, 0.15, "cbs", "2026-03-01T00:00:00+00:00"),
+                    ("2026-02", 0.11, 0.16, "cbs", "2026-03-01T00:00:00+00:00"),
+                ]
+            )
+        assert "2 reference price row(s)" in caplog.text
 
 
 class TestGetReferencePrice:
@@ -845,11 +831,12 @@ class TestGetReferencePrice:
         assert price == pytest.approx(0.27)  # 2026-02 is latest ≤ 2026-06
 
     @pytest.mark.asyncio
-    async def test_fallback_logs_warning(self, data_store, hass):
+    async def test_fallback_logs_warning(self, data_store, hass, caplog):
         await data_store.initialise()
         self._insert(data_store, "2026-01")
-        data_store.get_reference_price("2026-06")
-        assert find_log_containing(hass, "fallback") is not None
+        with caplog.at_level(logging.WARNING):
+            data_store.get_reference_price("2026-06")
+        assert "fallback" in caplog.text
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_data(self, data_store):

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_event_bus.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_event_bus.py
@@ -1,5 +1,6 @@
 """Unit test (pytest) for event_bus module."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 import pytest
 from apps.v2g_liberty.event_bus import EventBus
@@ -12,15 +13,6 @@ from appdaemon.plugins.hass.hassapi import Hass
 # W0719 - Catching Exception is safe in event wrapper testing
 
 
-def get_log_message(log_call):
-    """Extract the log message from the call arguments."""
-    if log_call and log_call.args:
-        return log_call.args[0]
-    elif log_call and log_call.kwargs:
-        return log_call.kwargs.get("msg", "")
-    return ""
-
-
 @pytest.fixture
 def hass():
     return AsyncMock(spec=Hass)
@@ -31,11 +23,11 @@ def event_bus(hass):
     return EventBus(hass)
 
 
-def test_initialization(event_bus, hass):
-    assert event_bus.hass == hass
-    log_call = hass.log.call_args
-    assert "EventBus initialized successfully." in get_log_message(log_call)
-    assert log_call.kwargs.get("level") == "INFO"
+def test_initialization(hass, caplog):
+    with caplog.at_level(logging.INFO):
+        bus = EventBus(hass)
+    assert bus.hass == hass
+    assert "EventBus initialized successfully." in caplog.text
 
 
 def test_add_event_listener_and_emit_event(event_bus):
@@ -51,17 +43,15 @@ def test_add_event_listener_and_emit_event(event_bus):
     assert called[0] == (("arg1",), {"key": "value"})
 
 
-def test_add_event_listener_duplicate_warning(event_bus, hass):
+def test_add_event_listener_duplicate_warning(event_bus, hass, caplog):
     def mock_listener(*_args, **_kwargs):
         pass
 
-    event_bus.add_event_listener("test_event", mock_listener)
-    event_bus.add_event_listener("test_event", mock_listener)
+    with caplog.at_level(logging.WARNING):
+        event_bus.add_event_listener("test_event", mock_listener)
+        event_bus.add_event_listener("test_event", mock_listener)
 
-    log_call = hass.log.call_args
-    log_message = get_log_message(log_call)
-    assert "already registered" in log_message
-    assert log_call.kwargs.get("level") == "WARNING"
+    assert "already registered" in caplog.text
 
 
 def test_remove_event_listener(event_bus):
@@ -77,66 +67,55 @@ def test_remove_event_listener(event_bus):
     assert "called" not in called
 
 
-def test_remove_event_listener_not_found(event_bus, hass):
+def test_remove_event_listener_not_found(event_bus, hass, caplog):
     def mock_listener(*_args, **_kwargs):
         pass
 
-    event_bus.remove_event_listener("test_event", mock_listener)
-    log_call = hass.log.call_args
-    assert "not found" in get_log_message(log_call)
-    assert log_call.kwargs.get("level") == "WARNING"
+    with caplog.at_level(logging.WARNING):
+        event_bus.remove_event_listener("test_event", mock_listener)
+
+    assert "not found" in caplog.text
 
 
-def test_emit_event_no_listeners_logs_warning(event_bus, hass):
-    event_bus.emit_event("no_listener_event", 1, test="x")
-    log_call = hass.log.call_args
-    assert "has no listeners" in get_log_message(log_call)
-    assert log_call.kwargs.get("level") == "WARNING"
+def test_emit_event_no_listeners_logs_warning(event_bus, hass, caplog):
+    with caplog.at_level(logging.WARNING):
+        event_bus.emit_event("no_listener_event", 1, test="x")
+
+    assert "has no listeners" in caplog.text
 
 
-def test_emit_event_with_exception(event_bus, hass):
+def test_emit_event_with_exception(event_bus, hass, caplog):
     def mock_listener(*args, **kwargs):
         raise Exception("Oops!")
 
     event_bus.add_event_listener("err_event", mock_listener)
-    event_bus.emit_event("err_event", 1)
 
-    log_call = hass.log.call_args
-    log_msg = get_log_message(log_call)
+    with caplog.at_level(logging.WARNING):
+        event_bus.emit_event("err_event", 1)
 
-    # ✅ Only check key parts
-    assert "err_event" in log_msg
-    assert "Oops!" in log_msg
-    assert "Error" in log_msg
-
-    assert log_call.kwargs.get("level") == "WARNING"
+    assert "err_event" in caplog.text
+    assert "Oops!" in caplog.text
 
 
-def test_add_event_listener_with_exception(event_bus, hass):
+def test_add_event_listener_with_exception(event_bus, hass, caplog):
     def mock_listener(*_args, **_kwargs):
         pass
 
-    with patch.object(event_bus, "listeners", side_effect=Exception("Boom!")):
-        event_bus.add_event_listener("faulty_add", mock_listener)
+    with caplog.at_level(logging.WARNING):
+        with patch.object(event_bus, "listeners", side_effect=Exception("Boom!")):
+            event_bus.add_event_listener("faulty_add", mock_listener)
 
-    log_call = hass.log.call_args
-    assert (
-        "Error while adding listener to event 'faulty_add': Boom!"
-        in get_log_message(log_call)
-    )
-    assert log_call.kwargs.get("level") == "WARNING"
+    assert "Error while adding listener to event 'faulty_add': Boom!" in caplog.text
 
 
-def test_remove_event_listener_with_exception(event_bus, hass):
+def test_remove_event_listener_with_exception(event_bus, hass, caplog):
     def mock_listener(*_args, **_kwargs):
         pass
 
-    with patch.object(event_bus, "listeners", side_effect=Exception("Boom!")):
-        event_bus.remove_event_listener("faulty_remove", mock_listener)
+    with caplog.at_level(logging.WARNING):
+        with patch.object(event_bus, "listeners", side_effect=Exception("Boom!")):
+            event_bus.remove_event_listener("faulty_remove", mock_listener)
 
-    log_call = hass.log.call_args
     assert (
-        "Error while removing listener from event 'faulty_remove': Boom!"
-        in get_log_message(log_call)
+        "Error while removing listener from event 'faulty_remove': Boom!" in caplog.text
     )
-    assert log_call.kwargs.get("level") == "WARNING"

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_log_wrapper.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_log_wrapper.py
@@ -1,0 +1,77 @@
+"""Unit tests for log_wrapper module.
+
+Verifies that the logging wrapper:
+- Produces log output via Python's standard logging (caplog)
+- Works from worker threads (run_in_executor) without crashing
+- Maps level strings correctly
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from apps.v2g_liberty.log_wrapper import get_class_method_logger
+
+
+class TestGetClassMethodLogger:
+    def test_info_message(self, caplog):
+        log = get_class_method_logger(module_name="test_mod")
+        with caplog.at_level(logging.DEBUG):
+            log("hello from test")
+        assert "hello from test" in caplog.text
+
+    def test_warning_level(self, caplog):
+        log = get_class_method_logger(module_name="test_mod")
+        with caplog.at_level(logging.DEBUG):
+            log("something went wrong", level="WARNING")
+        assert "something went wrong" in caplog.text
+        assert caplog.records[-1].levelno == logging.WARNING
+
+    def test_empty_level_defaults_to_info(self, caplog):
+        log = get_class_method_logger(module_name="test_mod")
+        with caplog.at_level(logging.DEBUG):
+            log("default level")
+        assert caplog.records[-1].levelno == logging.INFO
+
+    def test_invalid_level_defaults_to_info(self, caplog):
+        log = get_class_method_logger(module_name="test_mod")
+        with caplog.at_level(logging.DEBUG):
+            log("bogus level", level="BOGUS")
+        assert caplog.records[-1].levelno == logging.INFO
+
+    def test_default_module_name(self, caplog):
+        """An empty module_name should still produce a working logger."""
+        log = get_class_method_logger()
+        with caplog.at_level(logging.DEBUG):
+            log("still works")
+        assert "still works" in caplog.text
+
+    def test_logger_name_includes_module(self, caplog):
+        log = get_class_method_logger(module_name="my_module")
+        with caplog.at_level(logging.DEBUG):
+            log("check name")
+        assert caplog.records[-1].name == "AppDaemon.v2g-app.my_module"
+
+
+class TestThreadSafety:
+    @pytest.mark.asyncio
+    async def test_logging_from_executor_thread(self, caplog):
+        """Verify that log_wrapper works from a worker thread (run_in_executor).
+
+        This is the core scenario that previously crashed with:
+        RuntimeError: Non-thread-safe operation invoked on an event loop
+        other than the current one (via AppDaemon's LogSubscriptionHandler).
+        """
+        log = get_class_method_logger(module_name="test_thread")
+
+        def work_in_thread():
+            log("message from worker thread")
+            log("warning from worker thread", level="WARNING")
+
+        with caplog.at_level(logging.DEBUG):
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, work_in_thread)
+
+        assert "message from worker thread" in caplog.text
+        assert "warning from worker thread" in caplog.text

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_monitor_pause_at_reconnect.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_monitor_pause_at_reconnect.py
@@ -1,9 +1,11 @@
+import logging
 import pytest
 from unittest.mock import AsyncMock, MagicMock, call, ANY
 from apps.v2g_liberty.monitor_pause_at_reconnect import MonitorPauseAtReconnect
 from apps.v2g_liberty import constants as c
 from apps.v2g_liberty.event_bus import EventBus
 from apps.v2g_liberty.notifier_util import Notifier
+
 
 @pytest.fixture
 def mock_hass():
@@ -13,27 +15,33 @@ def mock_hass():
     hass.turn_on = AsyncMock()
     return hass
 
+
 @pytest.fixture
 def mock_event_bus():
     bus = AsyncMock(spec=EventBus)
     bus.add_event_listener = MagicMock()
     return bus
 
+
 @pytest.fixture
 def mock_notifier():
     return AsyncMock(spec=Notifier)
+
 
 @pytest.fixture
 def monitor(mock_hass, mock_event_bus, mock_notifier):
     return MonitorPauseAtReconnect(mock_hass, mock_event_bus, mock_notifier)
 
-def test_init(monitor, mock_hass, mock_event_bus):
+
+def test_init(mock_hass, mock_event_bus, mock_notifier, caplog):
     """Test that the module initializes correctly and subscribes to events."""
+    with caplog.at_level(logging.INFO):
+        monitor = MonitorPauseAtReconnect(mock_hass, mock_event_bus, mock_notifier)
     mock_event_bus.add_event_listener.assert_called_once_with(
         "is_car_connected", monitor._handle_connected_state_change
     )
-    args, kwargs = mock_hass.log.call_args
-    assert "Completed MonitorPauseAtReconnect" in kwargs["msg"]
+    assert "Completed MonitorPauseAtReconnect" in caplog.text
+
 
 @pytest.mark.asyncio
 async def test_handle_connected_state_change_disconnected(monitor, mock_hass):
@@ -42,6 +50,7 @@ async def test_handle_connected_state_change_disconnected(monitor, mock_hass):
     mock_hass.get_state.assert_not_called()
     monitor.notifier.notify_user.assert_not_called()
 
+
 @pytest.mark.asyncio
 async def test_handle_connected_state_change_automatic(monitor, mock_hass):
     """Test that nothing happens when charge mode is Automatic."""
@@ -49,6 +58,7 @@ async def test_handle_connected_state_change_automatic(monitor, mock_hass):
     await monitor._handle_connected_state_change(True)
     mock_hass.get_state.assert_called_once_with("input_select.charge_mode", None)
     monitor.notifier.notify_user.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_handle_connected_state_change_pause(monitor, mock_hass, mock_notifier):
@@ -61,10 +71,11 @@ async def test_handle_connected_state_change_pause(monitor, mock_hass, mock_noti
         title="Car connected, the app is set to 'Pause'",
         tag=monitor.NOTIFICATION_TAG,
         send_to_all=True,
-        ttl=30*60,
+        ttl=30 * 60,
         actions=ANY,
         callback=monitor._handle_chosen_charge_mode,
     )
+
 
 @pytest.mark.asyncio
 async def test_handle_connected_state_change_stop(monitor, mock_hass, mock_notifier):
@@ -77,10 +88,11 @@ async def test_handle_connected_state_change_stop(monitor, mock_hass, mock_notif
         title="Car connected, the app is set to 'Pause'",
         tag=monitor.NOTIFICATION_TAG,
         send_to_all=True,
-        ttl=30*60,
+        ttl=30 * 60,
         actions=ANY,
         callback=monitor._handle_chosen_charge_mode,
     )
+
 
 @pytest.mark.asyncio
 async def test_handle_connected_state_change_charge(monitor, mock_hass, mock_notifier):
@@ -93,28 +105,41 @@ async def test_handle_connected_state_change_charge(monitor, mock_hass, mock_not
         title="Car connected, the app is set to 'Charge'",
         tag=monitor.NOTIFICATION_TAG,
         send_to_all=True,
-        ttl=30*60,
+        ttl=30 * 60,
         actions=ANY,
         callback=monitor._handle_chosen_charge_mode,
     )
+
 
 @pytest.mark.asyncio
 async def test_handle_chosen_charge_mode_automatic(monitor, mock_hass, mock_notifier):
     """Test that the charge mode is set to Automatic when user chooses so."""
     await monitor._handle_chosen_charge_mode(monitor.ACTION_TO_AUTOMATIC)
-    mock_notifier.clear_notification.assert_called_once_with(tag=monitor.NOTIFICATION_TAG)
+    mock_notifier.clear_notification.assert_called_once_with(
+        tag=monitor.NOTIFICATION_TAG
+    )
     mock_hass.turn_on.assert_called_once_with("input_boolean.chargemodeautomatic")
 
-@pytest.mark.asyncio
-async def test_handle_chosen_charge_mode_keep_current(monitor, mock_hass, mock_notifier):
-    """Test that nothing happens when user chooses to keep current mode."""
-    await monitor._handle_chosen_charge_mode(monitor.ACTION_KEEP_CURRENT)
-    mock_notifier.clear_notification.assert_called_once_with(tag=monitor.NOTIFICATION_TAG)
-    mock_hass.turn_on.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_handle_chosen_charge_mode_unknown(monitor, mock_hass, mock_notifier, caplog):
+async def test_handle_chosen_charge_mode_keep_current(
+    monitor, mock_hass, mock_notifier
+):
+    """Test that nothing happens when user chooses to keep current mode."""
+    await monitor._handle_chosen_charge_mode(monitor.ACTION_KEEP_CURRENT)
+    mock_notifier.clear_notification.assert_called_once_with(
+        tag=monitor.NOTIFICATION_TAG
+    )
+    mock_hass.turn_on.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_chosen_charge_mode_unknown(
+    monitor, mock_hass, mock_notifier, caplog
+):
     """Test that a warning is logged for unknown user actions."""
     await monitor._handle_chosen_charge_mode("unknown_action")
-    mock_notifier.clear_notification.assert_called_once_with(tag=monitor.NOTIFICATION_TAG)
+    mock_notifier.clear_notification.assert_called_once_with(
+        tag=monitor.NOTIFICATION_TAG
+    )
     mock_hass.turn_on.assert_not_called()

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_nissan_leaf_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_nissan_leaf_monitor.py
@@ -1,5 +1,6 @@
 """Unit test (pytest) for nissan_leaf_monitor module."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 from apps.v2g_liberty.nissan_leaf_monitor import NissanLeafMonitor
@@ -7,7 +8,7 @@ from apps.v2g_liberty.nissan_leaf_monitor import NissanLeafMonitor
 
 @pytest.fixture
 def mock_hass():
-    """Mock Home Assistant API with a log method we can inspect."""
+    """Mock Home Assistant API."""
     hass = MagicMock()
     hass.log = MagicMock()
     hass.run_in = AsyncMock()
@@ -32,37 +33,19 @@ def nissan_leaf_monitor(mock_hass, mock_event_bus, mock_notifier):
     return NissanLeafMonitor(mock_hass, mock_event_bus, mock_notifier)
 
 
-def _msg_contains(call, *parts):
-    """Check if all parts appear in the msg kwarg."""
-    msg = call.kwargs.get("msg", "")
-    return all(str(p) in msg for p in parts)
-
-
-def _dump_logs(mock_hass):
-    """Return all logged messages for debugging."""
-    return "\n".join(c.kwargs.get("msg", "") for c in mock_hass.log.call_args_list)
-
-
 @pytest.mark.asyncio
 async def test_handle_soc_change_skip(
-    nissan_leaf_monitor, mock_hass, mock_event_bus, mock_notifier
+    nissan_leaf_monitor, mock_hass, mock_event_bus, mock_notifier, caplog
 ):
     new_soc = 19
     old_soc = 21
 
-    await nissan_leaf_monitor._handle_soc_change(new_soc, old_soc)
+    with caplog.at_level(logging.WARNING):
+        await nissan_leaf_monitor._handle_soc_change(new_soc, old_soc)
 
-    # Look at hass.log calls directly
-    if not any(
-        _msg_contains(
-            call, "SoC change jump", f"old_soc '{old_soc}'", f"new_soc '{new_soc}'"
-        )
-        and call.kwargs.get("level") == "WARNING"
-        for call in mock_hass.log.call_args_list
-    ):
-        pytest.fail(
-            f"Expected skip log not found. Actual logs:\n{_dump_logs(mock_hass)}"
-        )
+    assert "SoC change jump" in caplog.text
+    assert f"old_soc '{old_soc}'" in caplog.text
+    assert f"new_soc '{new_soc}'" in caplog.text
 
     mock_notifier.notify_user.assert_called_once()
     notify_kwargs = mock_notifier.notify_user.call_args.kwargs
@@ -76,20 +59,17 @@ async def test_handle_soc_change_skip(
 
 @pytest.mark.asyncio
 async def test_handle_soc_change_invalid_soc(
-    nissan_leaf_monitor, mock_hass, mock_event_bus, mock_notifier
+    nissan_leaf_monitor, mock_hass, mock_event_bus, mock_notifier, caplog
 ):
     new_soc = None
     old_soc = "unknown"
 
-    await nissan_leaf_monitor._handle_soc_change(new_soc, old_soc)
+    with caplog.at_level(logging.INFO):
+        await nissan_leaf_monitor._handle_soc_change(new_soc, old_soc)
 
-    if not any(
-        _msg_contains(call, "Aborting: new_soc", f"'{new_soc}'", f"'{old_soc}'")
-        for call in mock_hass.log.call_args_list
-    ):
-        pytest.fail(
-            f"Expected abort log not found. Actual logs:\n{_dump_logs(mock_hass)}"
-        )
+    assert "Aborting: new_soc" in caplog.text
+    assert f"'{new_soc}'" in caplog.text
+    assert f"'{old_soc}'" in caplog.text
 
     mock_notifier.notify_user.assert_not_called()
     mock_event_bus.remove_event_listener.assert_not_called()


### PR DESCRIPTION
**Titel:** Migrate logging from hass.log to Python standard logging

## Summary

- Migrate all logging from AppDaemon's `hass.log()` to Python's standard `logging` module, fixing thread-safety crashes in `run_in_executor` code and enabling runtime log level control
- Add `v2g_enable_debug_logging` developer event to toggle debug logging from HA Developer Tools with auto-disable timer
- Convert 25+ verbose log statements to DEBUG level to reduce log noise (~37% reduction)

## What changed

**Logging infrastructure (`log_wrapper.py`):**
- Replaced `inspect.stack()` + `hass.log()` with `sys._getframe()` + `logging.getLogger()`
- Thread-safe: no more `LogSubscriptionHandler.emit()` crashes from executor threads
- Caller info (line number, function name) still embedded in each message
- All 24 modules updated with `module_name` parameter

**Debug logging toggle (`api_server.py`):**
- New HA event `v2g_enable_debug_logging` with optional `duration_hours` (default 1, max 24)
- Auto-disables via `set_oneshot_timer`; resets to INFO on app restart

**Log noise reduction:**
- 15 `pass # log silenced` statements in `modbus_evse_client.py` restored as `level="DEBUG"`
- 10 commented-out log statements across 5 modules restored as `level="DEBUG"`
- Verbose chart clearing and calendar polling logs downgraded to DEBUG

**Other:**
- Log files renamed to `v2g_liberty_main.log` / `v2g_liberty_error.log`
- CBS fetcher `_log` in `reference_price_manager` made thread-safe
- New `docs/developer-events.md` documenting all developer events
- 17 test assertions migrated from `hass.log.call_args` to pytest `caplog`
- 7 new tests in `test_log_wrapper.py` including thread-safety verification

## Test plan

- [x] All 681 tests pass
- [x] Thread-safety verified: `data_repairer.run_full_repair_async()` logs from executor without crash
- [x] CBS fetcher logs from executor without `LogSubscriptionHandler` error
- [x] Log format verified in devcontainer: `module_name: lineno > func > message`
- [x] Test `v2g_enable_debug_logging` event from HA Developer Tools
- [x] Verify log files appear as `v2g_liberty_main.log` after restart