### PR TITLE
Exclude __pycache__ from AppDaemon app discovery

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.devcontainer.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.devcontainer.yaml
@@ -13,6 +13,7 @@ appdaemon:
   # Exclude utility module directories from app discovery.
   # These contain helper modules with relative imports, not apps.
   exclude_dirs:
+    - __pycache__
     - chargers
     - data_import
     - evs


### PR DESCRIPTION
To prevent flooding of the logs with
WARNING AppDaemon: Excessive time spent in utility loop: 2.8s, 2.8s in check_app_updates(), 7.988ms in other
