### PR TITLE
Fix perpetual SQLite lock and accept FlexMeasures HTTP 202

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- 🪲 BUG: Fix perpetual database is lock + Accept FM HTTP 202 when posting sensor data (#453)
 - 🪲 BUG: Fix broken UI (ha-xyz elements) on HA 2026.5+ (#452)
 - 🪲 BUG: Reduce excessive FM schedule requests on SoC changes (#446)
 - 🪲 BUG: Fix orphaned schedule timers overriding charge mode changes (#444)

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -7,6 +7,7 @@ That file also contains possible changes that the next release might include.
 
 ### Fixed
 
+- 🪲 BUG: Fix perpetual database is lock + Accept FM HTTP 202 when posting sensor data (#453)
 - 🪲 BUG: Fix broken UI (ha-xyz elements) on HA 2026.5+ (#452)
 - 🪲 BUG: Reduce excessive FM schedule requests on SoC changes (#446)
 - 🪲 BUG: Fix orphaned schedule timers overriding charge mode changes (#444)

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_repairer.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_repairer.py
@@ -76,6 +76,14 @@ class DataRepairer:
     def __init__(self, hass: Hass):
         self.__hass = hass
         self.__log = get_class_method_logger(module_name="data_repairer")
+        # Single-flight guard: only one repair (full or incremental) may run at
+        # a time. Repairs write the whole interval_log in big transactions;
+        # overlapping runs (e.g. the post-import full repair colliding with the
+        # API-triggered one or the 6-hourly incremental) hold the SQLite write
+        # lock long enough to starve the live 5-min monitoring writes
+        # ("database is locked"). The flag is only ever read/written on the
+        # event loop, so a plain boolean is race-free here.
+        self._repair_running = False
 
     async def initialise(self):
         """Schedule periodic incremental repair runs.
@@ -106,6 +114,15 @@ class DataRepairer:
         its own file lock, so concurrent writes from data_monitor /
         fm_data_importer simply wait their turn.
         """
+        if self._repair_running:
+            self.__log(
+                "Full repair requested while a repair is already running — "
+                "skipping this trigger.",
+                level="WARNING",
+            )
+            return
+        self._repair_running = True
+
         db_path = self.data_store.DB_PATH
 
         def _run_with_own_connection() -> dict:
@@ -143,6 +160,7 @@ class DataRepairer:
                 ),
                 notification_id=self._MEMO_ID,
             )
+            self._repair_running = False
             return
 
         # Success — dismiss any leftover notification from a previous failure.
@@ -164,6 +182,7 @@ class DataRepairer:
             )
 
         self._emit_repairer_complete()
+        self._repair_running = False
 
     def run_full_repair(self, conn=None) -> dict:
         """Repair entire interval_log from first to last record.
@@ -191,15 +210,25 @@ class DataRepairer:
 
     async def run_incremental_repair(self, _kwargs=None):
         """Repair the last PERIODIC_LOOKBACK_HOURS hours."""
-        now = get_local_now()
-        start = (now - timedelta(hours=PERIODIC_LOOKBACK_HOURS)).isoformat()
-        end = now.isoformat()
+        if self._repair_running:
+            self.__log(
+                "Incremental repair skipped — a repair is already running.",
+                level="WARNING",
+            )
+            return
+        self._repair_running = True
+        try:
+            now = get_local_now()
+            start = (now - timedelta(hours=PERIODIC_LOOKBACK_HOURS)).isoformat()
+            end = now.isoformat()
 
-        summary = self._repair_range(start, end)
-        total = _total_repairs(summary)
-        if total > 0:
-            self.__log(f"Incremental repair: {_format_summary(summary)}")
-        self._emit_repairer_complete()
+            summary = self._repair_range(start, end)
+            total = _total_repairs(summary)
+            if total > 0:
+                self.__log(f"Incremental repair: {_format_summary(summary)}")
+            self._emit_repairer_complete()
+        finally:
+            self._repair_running = False
 
     def _emit_repairer_complete(self):
         """Notify listeners that a repair run has finished."""

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_store.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_store.py
@@ -302,6 +302,13 @@ class DataStore:
         cursor.execute("PRAGMA journal_mode = WAL")
         cursor.execute("PRAGMA synchronous = NORMAL")
         cursor.execute("PRAGMA temp_store = MEMORY")
+        # Wait (instead of failing immediately with "database is locked") when
+        # another connection holds the write lock. The data_repairer runs on its
+        # own connection in a background thread; without a generous busy_timeout
+        # the shared connection's default of 5s is too short and writes such as
+        # upsert_emissions fail during a concurrent repair. 30s matches the
+        # repairer's own connection timeout.
+        cursor.execute("PRAGMA busy_timeout = 30000")
         cursor.close()
 
     def __create_tables(self):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import math
+import re
 from datetime import datetime, timedelta
 from pyee.asyncio import AsyncIOEventEmitter
 import isodate
@@ -706,6 +707,20 @@ class FMClient(AsyncIOEventEmitter):
                 unit=uom,
             )
         except Exception as e:
+            # flexmeasures-client raises ValueError("Request failed with status
+            # code NNN") when the response status is not its single expected
+            # status. FlexMeasures returns 202 (Accepted) for sensor-data posts,
+            # which the client (0.8.1) does not whitelist. A 2xx status means the
+            # data was accepted by FM, so treat it as success rather than a
+            # failure (which would otherwise retry forever and flag FM as down).
+            match = re.search(r"status code (\d{3})", str(e))
+            if match and 200 <= int(match.group(1)) < 300:
+                self.__log(
+                    f"accepted (HTTP {match.group(1)}) | sensor_id: '{sensor_id}', "
+                    f"start: '{start}', duration: '{duration}', unit: '{uom}'.",
+                    level="DEBUG",
+                )
+                return True
             self.__log(
                 f"failed | sensor_id: '{sensor_id}', values: '{values}', "
                 f"start: '{start}', duration: '{duration}', unit: '{uom}', "

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_repairer.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_repairer.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -682,7 +682,7 @@ class TestLinearSocInterpolation:
         _insert_interval(initialised_store, _ts(5), soc=None, energy=0.0)
         _insert_interval(initialised_store, _ts(10), soc=50.0, energy=0.0)
 
-        summary = repairer.run_full_repair()
+        repairer.run_full_repair()
         # Could be filled by linear interp or Type D — either is fine
         rows = _get_all_intervals(initialised_store)
         assert rows[1]["soc_pct"] == pytest.approx(50.0, abs=0.2)
@@ -1410,3 +1410,41 @@ class TestPendingReview:
         filled = [r for r in rows if r["timestamp"] not in (_ts(0), _ts(15))]
         for r in filled:
             assert r["is_repaired"] == 1
+
+
+class TestRepairSingleFlight:
+    """Only one repair (full or incremental) may run at a time.
+
+    Overlapping repairs hold the SQLite write lock long enough to starve the
+    live 5-min monitoring writes ("database is locked").
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_repair_skipped_when_already_running(self, repairer):
+        repairer.run_full_repair = MagicMock()
+        repairer._repair_running = True
+
+        await repairer.run_full_repair_async()
+
+        # Skipped before doing any DB work; the in-progress flag is untouched.
+        repairer.run_full_repair.assert_not_called()
+        assert repairer._repair_running is True
+
+    @pytest.mark.asyncio
+    async def test_flag_reset_after_full_repair(self, repairer, hass):
+        hass.call_service = MagicMock()
+        repairer.run_full_repair = MagicMock(return_value=_empty_summary())
+
+        await repairer.run_full_repair_async()
+
+        repairer.run_full_repair.assert_called_once()
+        assert repairer._repair_running is False
+
+    @pytest.mark.asyncio
+    async def test_incremental_repair_skipped_when_running(self, repairer):
+        repairer._repair_range = MagicMock()
+        repairer._repair_running = True
+
+        await repairer.run_incremental_repair()
+
+        repairer._repair_range.assert_not_called()

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_fm_client_provisioning.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_fm_client_provisioning.py
@@ -413,3 +413,57 @@ class TestSetAssetAttributes:
             "capacity_per_phase": 25,
             "v2g-liberty-version": "1.2.3",
         }
+
+
+class TestPostSensorData:
+    """post_sensor_data treats a 2xx 'failure' from the client as success.
+
+    FlexMeasures returns 202 (Accepted) for sensor-data posts; the
+    flexmeasures-client raises ValueError('Request failed with status code 202')
+    because it whitelists only one status. The data was accepted, so we must
+    not report a failure (which would retry forever and flag FM as down).
+    """
+
+    @pytest.mark.asyncio
+    async def test_202_is_treated_as_success(self, fm, fm_client_mock):
+        fm.set_fm_connection_status = AsyncMock()
+        fm_client_mock.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 202")
+        )
+        result = await fm.post_sensor_data(
+            sensor_id=5,
+            values=[0.1, 0.2],
+            start="2026-01-01T00:00:00+00:00",
+            duration="PT10M",
+            uom="kW",
+        )
+        assert result is True
+        fm.set_fm_connection_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_200_is_treated_as_success(self, fm, fm_client_mock):
+        fm_client_mock.post_sensor_data = AsyncMock(return_value=None)
+        result = await fm.post_sensor_data(
+            sensor_id=5,
+            values=[0.1],
+            start="2026-01-01T00:00:00+00:00",
+            duration="PT5M",
+            uom="kW",
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_error_status_is_a_failure(self, fm, fm_client_mock):
+        fm.set_fm_connection_status = AsyncMock()
+        fm_client_mock.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 500")
+        )
+        result = await fm.post_sensor_data(
+            sensor_id=5,
+            values=[0.1],
+            start="2026-01-01T00:00:00+00:00",
+            duration="PT5M",
+            uom="kW",
+        )
+        assert result is False
+        fm.set_fm_connection_status.assert_called_once_with(connected=False)


### PR DESCRIPTION
## Fix perpetual SQLite lock + accept FlexMeasures HTTP 202

### Problem (observed in production on 0.8.1)
Two independent issues stopped the new grid/PV monitoring data from reaching FlexMeasures:

1. **Perpetual "database is locked".** The data repairer could run concurrently/repeatedly — the post-import full repair colliding with the API-triggered run (`v2g_run_full_repair`) and the 6-hourly incremental repair. Each rewrites the whole `interval_log` (~112k rows) in one transaction, and overlapping runs held the SQLite write lock long enough to **permanently** starve the live 5-minute monitoring writes (`data_monitor._write_interval_to_db` failed every 5 min for 14+ hours). As a result `interval_log`/`grid_interval_log`/`pv_interval_log` stopped being written, so there was nothing to send.

2. **HTTP 202 treated as a failure.** FlexMeasures returns `202 Accepted` for sensor-data posts, but `flexmeasures-client` 0.8.1 raises `ValueError("Request failed with status code 202")` (it whitelists a single status). `fm_client.post_sensor_data` treated this as a failure, so the data was retried forever and FM was flagged as down — even though the data had been accepted.


### Fixes

- **Single-flight guard** in `data_repairer`: only one repair (full or incremental) may run at a time; overlapping triggers are skipped. This addresses the repeated/overlapping repairs that caused the lock.
- **`PRAGMA busy_timeout = 30000`** on the shared `DataStore` connection as a backstop against short-lived contention.
- **`post_sensor_data`** now treats any HTTP 2xx (including 202) as success instead of a failure.
- Tests for the 202 handling (202/200/error) and the single-flight repair guard.

### Verification in production
After deploying these fixes and upgrading:
- No more "database is locked"; `grid_interval_log`/`pv_interval_log`/`interval_log` are being written again.
- `fm_send_status` for charger/grid/pv advanced past the frozen init timestamp — data is now accepted by FlexMeasures.

### Notes
- The 112k-row repair is no longer chunked into smaller transactions; the single-flight guard + `busy_timeout` proved sufficient in production, so chunking was intentionally left out to keep the change focused.