### PR TITLE
Forgotten remove of files

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Changed
 
-- 🛠️ Refactor: Exclude dev-only files (dev_tools, tests, dev config) from the production add-on image (#455)
+- 🛠️ Refactor: Exclude dev-only files (dev_tools, tests, dev config) from the production add-on image (#455, #457)
 - 🛠️ Refactor: Quieter add-on startup — copy without per-file logging and report each step (#455)
 - 🛠️ Refactor: Migrate to python logging (#448)
 - 🛠️ Refactor: make AppDaemon timer-API usage consistently async in main_app (#445)

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -20,7 +20,7 @@ That file also contains possible changes that the next release might include.
 
 ### Changed
 
-- 🛠️ Refactor: Exclude dev-only files (dev_tools, tests, dev config) from the production add-on image (#455)
+- 🛠️ Refactor: Exclude dev-only files (dev_tools, tests, dev config) from the production add-on image (#455, #457)
 - 🛠️ Refactor: Quieter add-on startup — copy without per-file logging and report each step (#455)
 - 🛠️ Refactor: Migrate to python logging (#448)
 - 🛠️ Refactor: make AppDaemon timer-API usage consistently async in main_app (#445)

--- a/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -13,6 +13,9 @@ mkdir -p /config/logs
 # Remove dev-only files that earlier versions copied into the persistent
 # /config. The copy below only adds/overwrites, so without this these stale
 # dev files would survive an upgrade. They are no longer in the image.
+# Introduced in 0.8.1. Can be removed once no installation upgrades from a
+# version below 0.8.1 anymore (HA jumps straight to the latest version, so a
+# 0.8.0 -> later install would otherwise skip this cleanup).
 rm -rf /config/apps/dev_tools \
     /config/tests \
     /config/appdaemon.devcontainer.yaml

--- a/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -10,9 +10,12 @@ bashio::log.info "Configuring V2G Liberty..."
 # Create directory where log files will be written
 mkdir -p /config/logs
 
-# Remove old v2g-liberty folder as it is renamed to v2g_liberty
-# Bug-fix release 0.4.1
-rm -rf /config/apps/v2g-liberty
+# Remove dev-only files that earlier versions copied into the persistent
+# /config. The copy below only adds/overwrites, so without this these stale
+# dev files would survive an upgrade. They are no longer in the image.
+rm -rf /config/apps/dev_tools \
+    /config/tests \
+    /config/appdaemon.devcontainer.yaml
 
 # Copy python files
 cp -aR /root/appdaemon/* /config \


### PR DESCRIPTION
A bit messy, forgotten changes to run script need to go into the git release chain again..
- Remove old files copied by earlier releases that have no value. 
- Removed obsolete rename of v2g-liberty folder