### PR TITLE
Sync main back into dev (0.8.1 version bump)

### DIFF
--- a/v2g-liberty/config.yaml
+++ b/v2g-liberty/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: V2G Liberty
-version: 0.8.0
+version: 0.8.1
 slug: v2g-liberty
 description: The V2G Liberty add-on delivers full automatic and optimised control over Vehicle to Grid (V2G) / bidirectional charging of your electric vehicle.
 url: https://github.com/V2G-liberty/addon-v2g-liberty

--- a/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/v2g-liberty/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -10,14 +10,16 @@ bashio::log.info "Configuring V2G Liberty..."
 # Create directory where log files will be written
 mkdir -p /config/logs
 
-# Remove dev-only files that earlier versions copied into the persistent
+# Remove dev-only files that earlier releases copied into the persistent
 # /config. The copy below only adds/overwrites, so without this these stale
-# dev files would survive an upgrade. They are no longer in the image.
-# Introduced in 0.8.1. Can be removed once no installation upgrades from a
-# version below 0.8.1 anymore (HA jumps straight to the latest version, so a
-# 0.8.0 -> later install would otherwise skip this cleanup).
-rm -rf /config/apps/dev_tools \
-    /config/tests \
+# files would survive an upgrade. They are no longer in the image as of 0.8.1.
+# NOTE: dev_tools/ is intentionally NOT removed here. It is new in 0.8.1 (so it
+# was never in an end-user's /config), and removing it on every start would
+# wipe a manually placed grid/PV emulator used for testing (see dev_tools/README).
+# Can be removed once no installation upgrades from a version below 0.8.1
+# anymore (HA jumps straight to the latest version, so a 0.8.0 -> later install
+# would otherwise skip this cleanup).
+rm -rf /config/tests \
     /config/appdaemon.devcontainer.yaml
 
 # Copy python files

--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.yaml
@@ -18,7 +18,6 @@ appdaemon:
   exclude_dirs:
     - chargers
     - data_import
-    - dev_tools
     - evs
     - grid_connection
     - util

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/README.md
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/README.md
@@ -67,15 +67,16 @@ Turn it off to resume.
 
 ### Running outside the dev container (e.g. on pre-production)
 
-The emulator is **dev-only** and is **stripped from the built add-on image** (see the `rm -rf …/dev_tools` in the repo `Dockerfile`), so it is **not present in production *or* pre-production add-ons**. (`appdaemon.yaml` additionally excludes `dev_tools` from app discovery.)
+The emulator is **dev-only** and is **stripped from the built add-on image** (`rm -rf …/dev_tools` in the `Dockerfile`), so a normal install never contains it.
 
-**Recommended:** run the emulator in the **dev container**, where it loads automatically from the repo. For most grid/PV UI, entity-validation and flow testing this is enough.
+**Recommended:** run it in the **dev container**, where it loads automatically from the repo. For most grid/PV UI, entity-validation and flow testing this is enough.
 
-If you specifically need it on a pre-production host, set it up by hand (temporary):
+If you do want it on a pre-production host, you can add it by hand — and it now survives restarts:
 
-1. Copy the `dev_tools/` directory into the running add-on's `…/appdaemon/apps/` directory — it is not in the built image, so you must add it (e.g. via the add-on's file access or `docker cp` into the container).
-2. Remove the `- dev_tools` line from that host's `appdaemon.yaml` `exclude_dirs` (leave the other entries — `chargers`, `evs`, `util`, etc. — in place) so AppDaemon discovers `dev_tools/apps.yaml`.
-3. Configure `dev_tools/apps.yaml` (`pv_panels`, `base_load`, `fuse_threshold`) and restart AppDaemon / the add-on.
-4. After ~10 seconds the `sensor.emulated_*` entities appear (Developer Tools → States). Use those entity IDs in the grid connection settings dialog; toggle `input_boolean.emulator_paused` to test the "no sensor activity" scenario.
+1. Place the `dev_tools/` directory in the add-on's `/config/apps/` directory (e.g. via the add-on's file access or `docker cp` into the container). The startup copy only adds/overwrites from the image, and the cleanup no longer touches `dev_tools/`, so your folder is kept.
+2. Restart AppDaemon / the add-on.
+3. After ~10 seconds the `sensor.emulated_*` entities appear (Developer Tools → States). Use those entity IDs in the grid connection settings dialog; toggle `input_boolean.emulator_paused` to test the "no sensor activity" scenario.
 
-> ⚠️ This is a temporary, manual test setup — a rebuild/redeploy removes it again. **Never enable the emulator on production.**
+No `appdaemon.yaml` edit is needed: `dev_tools` is no longer listed under `exclude_dirs`, so AppDaemon discovers `/config/apps/dev_tools/apps.yaml` once the folder is present. (On a normal install the folder isn't there, so nothing is loaded.)
+
+> ⚠️ **Never place the emulator on a real production install** — it would emit fake meter/PV data.


### PR DESCRIPTION
## Sync `main` back into `dev`

**Base:** `dev` · **Merge from:** `main`

Brings the release edit that was made directly on `main` back into `dev`, so the branches are in sync again.

### What actually changes
Only the add-on version:
- `config.yaml`: `version: 0.8.0` → `0.8.1`