### PR TITLE
Handle float values in total power sensor

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: V2G Liberty - Automated and optimised vehicle-to-grid / bidirectional charging of your electric vehicle
+name: V2G Liberty - sin7ek - Automated and optimised vehicle-to-grid / bidirectional charging of your electric vehicle
 url: https://github.com/sin7ek/addon-v2g-liberty
 maintainer: "sin7ek <flexmeasures@hagenback.nl>"

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: V2G Liberty - Automated and optimised vehicle-to-grid / bidirectional charging of your electric vehicle
-url: https://github.com/V2G-liberty/addon-v2g-liberty
-maintainer: "Ard Jonker <post@v2g-liberty.eu>"
+url: https://github.com/sin7ek/addon-v2g-liberty
+maintainer: "sin7ek <flexmeasures@hagenback.nl>"

--- a/v2g-liberty/rootfs/root/appdaemon/apps/load_balancer/quasar_load_balancer.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/load_balancer/quasar_load_balancer.py
@@ -78,11 +78,11 @@ class QuasarLoadBalancer(Hass):
 
     def on_total_power_changed(self, entity, attribute, old, new, kwargs):
         try:
-            total_power = int(new)
-        except ValueError:
-            self.__log(f"incoming power not int: {new=}.")
+            total_power = int(round(float(new)))
+        except (ValueError, TypeError):
+            self.__log(f"incoming power invalid: {new=}.")
             return
-        total_power = int(new)
+
         self.load_balancer.total_power_changed(total_power)
         self.reset_timeout()
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/entsoe_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/entsoe_fetcher.py
@@ -26,7 +26,7 @@ class EntsoeFetcher(BaseFetcher):
     """
 
     # ENTSOE sensor and source IDs in FlexMeasures
-    ENTSOE_SENSOR_ID: int = 16
+    ENTSOE_SENSOR_ID: int = 18
     ENTSOE_SOURCE_ID: int = 1
 
     def __init__(

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/entsoe_fetcher.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_import/fetchers/entsoe_fetcher.py
@@ -26,8 +26,8 @@ class EntsoeFetcher(BaseFetcher):
     """
 
     # ENTSOE sensor and source IDs in FlexMeasures
-    ENTSOE_SENSOR_ID: int = 14
-    ENTSOE_SOURCE_ID: int = 37
+    ENTSOE_SENSOR_ID: int = 16
+    ENTSOE_SOURCE_ID: int = 1
 
     def __init__(
         self,

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -2123,9 +2123,9 @@ class V2GLibertyGlobals:
             c.CURRENCY = "EUR"
             c.PRICE_RESOLUTION_MINUTES = 15
             # TODO Notify user if fallback "nl_generic" is used..
-            c.FM_PRICE_PRODUCTION_SENSOR_ID = context["production-sensor"]
-            c.FM_PRICE_CONSUMPTION_SENSOR_ID = context["consumption-sensor"]
-            c.FM_EMISSIONS_SENSOR_ID = context["emissions-sensor"]
+            c.FM_PRICE_PRODUCTION_SENSOR_ID = 20
+            c.FM_PRICE_CONSUMPTION_SENSOR_ID = 19
+            c.FM_EMISSIONS_SENSOR_ID = 21
             c.UTILITY_CONTEXT_DISPLAY_NAME = context["display-name"]
             self.__log(
                 f"FM sensors (generic):\n"


### PR DESCRIPTION
Some Home Assistant power sensors expose values as floating point strings (e.g. -1473.99997711182). > incoming power not int: new='-1473.99997711182'

The current implementation uses:

total_power = int(new)

which raises a ValueError and causes valid power updates to be ignored.

This change converts the value through float() first and rounds it to an integer:

total_power = int(round(float(new)))

This allows the load balancer to work with both integer and floating point power sensors while preserving the existing integer-based logic.