### PR TITLE
Refactor: rename FlexMeasures "Main Connection" asset to "Mains Connection"

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # What's changed?
 
-ek ## 0.8.2 2026-06-??
+## 0.8.2 2026-06-19
 
 ### Fixed
 
@@ -12,7 +12,7 @@ ek ## 0.8.2 2026-06-??
 
 ### Changed
 
--
+- 🛠️ Refactor: Rename FlexMeasures "Main Connection" asset to "Mains Connection" (#466)
 
 #### Removing
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,11 +3,15 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
-## 0.8.2 2026-06-??
+## 0.8.2 2026-06-19
 
 ### Fixed
 
 - 🪲 BUG: Handle float values from the total power sensor in the load balancer (#465, thanks @sin7ek)
+
+### Changed
+
+- 🛠️ Refactor: Rename FlexMeasures "Main Connection" asset to "Mains Connection" (#466)
 
 ## 0.8.1 2026-06-12
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/constants.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/constants.py
@@ -150,7 +150,7 @@ FM_ACCOUNT_PASSWORD: str = ""
 
 # Name of the user's *charger* asset in FlexMeasures (e.g. "John's Quasar").
 # Historically called just FM_ASSET_NAME — predates the multi-asset model
-# (Main Connection / solar panels). A rename to FM_CHARGER_ASSET_NAME is
+# (Mains Connection / solar panels). A rename to FM_CHARGER_ASSET_NAME is
 # tracked in todo.md; deferred because it touches the on-disk settings
 # JSON, the HA input_text entity (`fm_asset`) and the cards UI.
 FM_ASSET_NAME: str = ""
@@ -233,7 +233,7 @@ GRID_PRODUCTION_ENTITIES: list[str] = []  # 1 or 3 HA entity IDs (raw meter valu
 
 # FM asset/sensor IDs for grid monitoring.
 # Set at runtime by __provision_grid_assets() in v2g_globals.
-FM_MAIN_CONNECTION_ASSET_ID: int | None = None
+FM_MAINS_CONNECTION_ASSET_ID: int | None = None
 FM_GRID_CONSUMPTION_SENSOR_IDS: dict[int, int] = {}  # phase → sensor_id
 FM_GRID_PRODUCTION_SENSOR_IDS: dict[int, int] = {}  # phase → sensor_id
 FM_AGGREGATE_POWER_SENSOR_ID: int | None = None

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -244,7 +244,7 @@ class FMClient(AsyncIOEventEmitter):
         object on a PATCH (confirmed against staging), so the current
         attributes are fetched and the new keys are merged in before writing.
         This prevents separate writers — e.g. grid phases/capacity
-        provisioning vs. version attributes on the Main Connection — from
+        provisioning vs. version attributes on the Mains Connection — from
         clobbering each other's keys.
         """
         if self.client is None:
@@ -356,7 +356,7 @@ class FMClient(AsyncIOEventEmitter):
             if attributes:
                 # Merge into the existing attributes: a PATCH replaces the whole
                 # attributes object on the FM side, so writing only the new keys
-                # would wipe others (e.g. version attributes on Main Connection).
+                # would wipe others (e.g. version attributes on Mains Connection).
                 merged = {**(match.get("attributes") or {}), **attributes}
                 await self.client.update_asset(existing_id, {"attributes": merged})
                 self.__log(f"Updated attributes for asset '{name}' (id={existing_id})")

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -602,7 +602,7 @@ class V2Gliberty:
             f"V2G Liberty version: {v2g_version}, Home Assistant version: {ha_version}"
         )
 
-        # Prefer the Main Connection asset (site-level metadata fits there);
+        # Prefer the Mains Connection asset (site-level metadata fits there);
         # the helper falls back to the charger asset when grid is not yet
         # configured so the version info is still visible somewhere in FM.
         try:
@@ -611,17 +611,17 @@ class V2Gliberty:
                     "v2g-liberty-version": v2g_version,
                     "home-assistant-version": ha_version,
                 },
-                asset_id=c.FM_MAIN_CONNECTION_ASSET_ID,
+                asset_id=c.FM_MAINS_CONNECTION_ASSET_ID,
             )
         except Exception as e:
             self.__log(f"Error writing versions to FlexMeasures: {e}", level="WARNING")
 
-        # When the versions just landed on the Main Connection, clear any
+        # When the versions just landed on the Mains Connection, clear any
         # stale version attributes still sitting on the charger asset so
         # there's a single canonical home. Idempotent: on later runs the
-        # nulls are written over nulls. Skip the cleanup when Main Connection
+        # nulls are written over nulls. Skip the cleanup when Mains Connection
         # is not yet provisioned — versions then *live* on the charger.
-        if c.FM_MAIN_CONNECTION_ASSET_ID is not None:
+        if c.FM_MAINS_CONNECTION_ASSET_ID is not None:
             try:
                 await self.fm_client_app.set_asset_attributes(
                     {

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -935,7 +935,7 @@ class V2GLibertyGlobals:
         by name) are reused.
 
         Raises ``RuntimeError`` with a user-facing message when FM is
-        not available (client disconnected, Main Connection asset
+        not available (client disconnected, Mains Connection asset
         missing). Underlying ``ensure_*`` exceptions propagate unchanged.
         The caller is expected to convert any exception into an
         ``fm_error`` response so the UI can show the message and offer
@@ -946,7 +946,7 @@ class V2GLibertyGlobals:
                 "FlexMeasures is not connected. "
                 "Configure FlexMeasures access and try again."
             )
-        if c.FM_MAIN_CONNECTION_ASSET_ID is None:
+        if c.FM_MAINS_CONNECTION_ASSET_ID is None:
             raise RuntimeError(
                 "Grid connection has not been registered with FlexMeasures. "
                 "Save the grid connection first."
@@ -966,7 +966,7 @@ class V2GLibertyGlobals:
         asset_id = await self.fm_client_app.ensure_asset(
             name=panel["name"],
             generic_asset_type="solar",
-            parent_asset_id=c.FM_MAIN_CONNECTION_ASSET_ID,
+            parent_asset_id=c.FM_MAINS_CONNECTION_ASSET_ID,
             attributes=asset_attributes,
             asset_id=panel.get("fm_asset_id"),
         )
@@ -1092,9 +1092,9 @@ class V2GLibertyGlobals:
                 "Configure FlexMeasures access and try again."
             )
 
-        # Main Connection asset
-        c.FM_MAIN_CONNECTION_ASSET_ID = await self.fm_client_app.ensure_asset(
-            name="Main Connection",
+        # Mains Connection asset
+        c.FM_MAINS_CONNECTION_ASSET_ID = await self.fm_client_app.ensure_asset(
+            name="Mains Connection",
             generic_asset_type="building",
             attributes={
                 "phases": c.GRID_PHASES,
@@ -1102,15 +1102,15 @@ class V2GLibertyGlobals:
             },
         )
 
-        # Re-parent charger asset under Main Connection
+        # Re-parent charger asset under Mains Connection
         if self.fm_client_app._charger_asset_id is not None:
             await self.fm_client_app.client.update_asset(
                 self.fm_client_app._charger_asset_id,
-                {"parent_asset_id": c.FM_MAIN_CONNECTION_ASSET_ID},
+                {"parent_asset_id": c.FM_MAINS_CONNECTION_ASSET_ID},
             )
             self.__log(
                 f"Set charger asset {self.fm_client_app._charger_asset_id} "
-                f"as child of Main Connection {c.FM_MAIN_CONNECTION_ASSET_ID}"
+                f"as child of Mains Connection {c.FM_MAINS_CONNECTION_ASSET_ID}"
             )
 
         # Grid sensors per phase
@@ -1120,7 +1120,7 @@ class V2GLibertyGlobals:
             ] = await self.fm_client_app.ensure_sensor(
                 name=f"Grid Consumption L{phase}",
                 unit="kW",
-                asset_id=c.FM_MAIN_CONNECTION_ASSET_ID,
+                asset_id=c.FM_MAINS_CONNECTION_ASSET_ID,
                 attributes={"consumption_is_positive": True},
             )
             c.FM_GRID_PRODUCTION_SENSOR_IDS[
@@ -1128,24 +1128,24 @@ class V2GLibertyGlobals:
             ] = await self.fm_client_app.ensure_sensor(
                 name=f"Grid Production L{phase}",
                 unit="kW",
-                asset_id=c.FM_MAIN_CONNECTION_ASSET_ID,
+                asset_id=c.FM_MAINS_CONNECTION_ASSET_ID,
             )
 
         # Aggregate Power sensor (written by FM scheduler, not by V2G Liberty)
         c.FM_AGGREGATE_POWER_SENSOR_ID = await self.fm_client_app.ensure_sensor(
             name="Aggregate Power",
             unit="kW",
-            asset_id=c.FM_MAIN_CONNECTION_ASSET_ID,
+            asset_id=c.FM_MAINS_CONNECTION_ASSET_ID,
         )
 
         # EMS Status sensor
         c.FM_EMS_STATUS_SENSOR_ID = await self.fm_client_app.ensure_sensor(
             name="EMS Status",
             unit="dimensionless",
-            asset_id=c.FM_MAIN_CONNECTION_ASSET_ID,
+            asset_id=c.FM_MAINS_CONNECTION_ASSET_ID,
         )
 
-        # Show all provisioned grid sensors on the Main Connection's FM
+        # Show all provisioned grid sensors on the Mains Connection's FM
         # page. sensors_to_show is a top-level asset field (not an
         # attribute), so phases/capacity stay untouched.
         sensors_to_show = []
@@ -1155,13 +1155,13 @@ class V2GLibertyGlobals:
         sensors_to_show.append(c.FM_AGGREGATE_POWER_SENSOR_ID)
         sensors_to_show.append(c.FM_EMS_STATUS_SENSOR_ID)
         await self.fm_client_app.client.update_asset(
-            c.FM_MAIN_CONNECTION_ASSET_ID,
+            c.FM_MAINS_CONNECTION_ASSET_ID,
             {"sensors_to_show": sensors_to_show},
         )
 
         self.__log(
             f"Grid FM provisioning complete: "
-            f"asset={c.FM_MAIN_CONNECTION_ASSET_ID}, "
+            f"asset={c.FM_MAINS_CONNECTION_ASSET_ID}, "
             f"consumption={c.FM_GRID_CONSUMPTION_SENSOR_IDS}, "
             f"production={c.FM_GRID_PRODUCTION_SENSOR_IDS}, "
             f"aggregate_power={c.FM_AGGREGATE_POWER_SENSOR_ID}, "

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_fm_client_provisioning.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_fm_client_provisioning.py
@@ -92,25 +92,25 @@ class TestEnsureAsset:
         fm_client_mock.get_assets.return_value = []
 
         asset_id = await fm.ensure_asset(
-            name="[TEST] Main Connection",
+            name="[TEST] Mains Connection",
             generic_asset_type="building",
         )
 
         assert asset_id == 100
         fm_client_mock.add_asset.assert_called_once()
         call_kwargs = fm_client_mock.add_asset.call_args.kwargs
-        assert call_kwargs["name"] == "[TEST] Main Connection"
+        assert call_kwargs["name"] == "[TEST] Mains Connection"
         assert call_kwargs["account_id"] == 42
 
     @pytest.mark.asyncio
     async def test_finds_existing_asset(self, fm, fm_client_mock):
         """Existing asset is found by name, not created."""
         fm_client_mock.get_assets.return_value = [
-            {"id": 55, "name": "[TEST] Main Connection", "sensors": []}
+            {"id": 55, "name": "[TEST] Mains Connection", "sensors": []}
         ]
 
         asset_id = await fm.ensure_asset(
-            name="[TEST] Main Connection",
+            name="[TEST] Mains Connection",
             generic_asset_type="building",
         )
 
@@ -121,11 +121,11 @@ class TestEnsureAsset:
     async def test_updates_attributes_on_existing(self, fm, fm_client_mock):
         """Attributes are updated when asset already exists."""
         fm_client_mock.get_assets.return_value = [
-            {"id": 55, "name": "[TEST] Main Connection", "sensors": []}
+            {"id": 55, "name": "[TEST] Mains Connection", "sensors": []}
         ]
 
         asset_id = await fm.ensure_asset(
-            name="[TEST] Main Connection",
+            name="[TEST] Mains Connection",
             generic_asset_type="building",
             attributes={"phases": 3, "capacity_per_phase": 25},
         )
@@ -139,11 +139,11 @@ class TestEnsureAsset:
     async def test_merges_attributes_on_existing(self, fm, fm_client_mock):
         """Existing attributes are preserved (merged) — a PATCH replaces the
         whole attributes object, so a phases/capacity write must not wipe the
-        version attributes already on the Main Connection."""
+        version attributes already on the Mains Connection."""
         fm_client_mock.get_assets.return_value = [
             {
                 "id": 55,
-                "name": "Main Connection",
+                "name": "Mains Connection",
                 "sensors": [],
                 "attributes": {
                     "v2g-liberty-version": "1.2.3",
@@ -153,7 +153,7 @@ class TestEnsureAsset:
         ]
 
         await fm.ensure_asset(
-            name="Main Connection",
+            name="Mains Connection",
             generic_asset_type="building",
             attributes={"phases": 3, "capacity_per_phase": 25},
         )
@@ -174,11 +174,11 @@ class TestEnsureAsset:
     async def test_no_update_without_attributes(self, fm, fm_client_mock):
         """No update_asset call when no attributes provided."""
         fm_client_mock.get_assets.return_value = [
-            {"id": 55, "name": "[TEST] Main Connection", "sensors": []}
+            {"id": 55, "name": "[TEST] Mains Connection", "sensors": []}
         ]
 
         await fm.ensure_asset(
-            name="[TEST] Main Connection",
+            name="[TEST] Mains Connection",
             generic_asset_type="building",
         )
 
@@ -208,7 +208,7 @@ class TestEnsureAsset:
         }
 
         await fm.ensure_asset(
-            name="[TEST] Main Connection",
+            name="[TEST] Mains Connection",
             generic_asset_type="building",
         )
 

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_log_versions.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_log_versions.py
@@ -27,15 +27,15 @@ def v2g():
 
 class TestLogVersions:
     @pytest.mark.asyncio
-    async def test_writes_to_main_connection_and_clears_charger(self, v2g):
-        """Main Connection present → versions written there + charger cleanup."""
-        with patch.object(c, "FM_MAIN_CONNECTION_ASSET_ID", 171):
+    async def test_writes_to_mains_connection_and_clears_charger(self, v2g):
+        """Mains Connection present → versions written there + charger cleanup."""
+        with patch.object(c, "FM_MAINS_CONNECTION_ASSET_ID", 171):
             await v2g.log_versions()
 
         calls = v2g.fm_client_app.set_asset_attributes.await_args_list
         assert len(calls) == 2
 
-        # First call: write the versions to the Main Connection.
+        # First call: write the versions to the Mains Connection.
         assert calls[0].args[0] == {
             "v2g-liberty-version": "1.2.3",
             "home-assistant-version": "2026.5.0",
@@ -50,9 +50,9 @@ class TestLogVersions:
         assert calls[1].kwargs == {"asset_id": None}
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_charger_without_main_connection(self, v2g):
-        """No Main Connection → single write (falls back to charger), no cleanup."""
-        with patch.object(c, "FM_MAIN_CONNECTION_ASSET_ID", None):
+    async def test_falls_back_to_charger_without_mains_connection(self, v2g):
+        """No Mains Connection → single write (falls back to charger), no cleanup."""
+        with patch.object(c, "FM_MAINS_CONNECTION_ASSET_ID", None):
             await v2g.log_versions()
 
         calls = v2g.fm_client_app.set_asset_attributes.await_args_list

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_v2g_globals_grid_settings.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_v2g_globals_grid_settings.py
@@ -915,13 +915,13 @@ class TestProvisionGridAssets:
 
         await globals_with_fm._V2GLibertyGlobals__provision_grid_assets()
 
-        # Main Connection asset created
+        # Mains Connection asset created
         fm_client_connected.ensure_asset.assert_called_once()
         asset_call = fm_client_connected.ensure_asset.call_args
-        assert "Main Connection" in asset_call.kwargs["name"]
+        assert "Mains Connection" in asset_call.kwargs["name"]
         assert asset_call.kwargs["attributes"]["phases"] == 3
 
-        assert c.FM_MAIN_CONNECTION_ASSET_ID == 500
+        assert c.FM_MAINS_CONNECTION_ASSET_ID == 500
 
         # 6 grid sensors + 1 Aggregate Power + 1 EMS Status = 8 ensure_sensor calls
         assert fm_client_connected.ensure_sensor.call_count == 8
@@ -984,10 +984,10 @@ class TestProvisionGridAssets:
             await globals_with_fm._V2GLibertyGlobals__provision_grid_assets()
 
     @pytest.mark.asyncio
-    async def test_main_connection_sensors_to_show(
+    async def test_mains_connection_sensors_to_show(
         self, globals_with_fm, fm_client_connected
     ):
-        """All provisioned grid sensors are written to the Main Connection's
+        """All provisioned grid sensors are written to the Mains Connection's
         top-level sensors_to_show field (not as an attribute)."""
         c.GRID_PHASES = 3
         c.GRID_CONSUMPTION_ENTITIES = ["sensor.l1", "sensor.l2", "sensor.l3"]
@@ -1003,7 +1003,7 @@ class TestProvisionGridAssets:
         ]
         assert len(sts_calls) == 1
         asset_id_arg, payload = sts_calls[0].args
-        assert asset_id_arg == c.FM_MAIN_CONNECTION_ASSET_ID
+        assert asset_id_arg == c.FM_MAINS_CONNECTION_ASSET_ID
 
         expected = []
         for phase in range(1, 4):
@@ -1020,7 +1020,7 @@ class TestChargerReparent:
 
     @pytest.mark.asyncio
     async def test_reparents_charger_asset(self, globals_with_fm, fm_client_connected):
-        """Charger asset is set as child of Main Connection."""
+        """Charger asset is set as child of Mains Connection."""
         c.GRID_PHASES = 1
         c.GRID_CONSUMPTION_ENTITIES = ["sensor.l1"]
         c.FM_GRID_CONSUMPTION_SENSOR_IDS = {}
@@ -1047,7 +1047,7 @@ class TestChargerReparent:
         await globals_with_fm._V2GLibertyGlobals__provision_grid_assets()
 
         # No reparent call when the charger asset id is unknown; the only
-        # update_asset call is the sensors_to_show write on Main Connection.
+        # update_asset call is the sensors_to_show write on Mains Connection.
         reparent_calls = [
             call_
             for call_ in fm_client_connected.client.update_asset.call_args_list

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_v2g_globals_solar_panel_settings.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_v2g_globals_solar_panel_settings.py
@@ -18,7 +18,7 @@ from apps.v2g_liberty.v2g_globals import V2GLibertyGlobals
 # care about the full saved record assert these in fm_asset_id / fm_sensor_id.
 _FM_ASSET_ID = 101
 _FM_SENSOR_ID = 201
-_FM_MAIN_CONNECTION_ID = 100
+_FM_MAINS_CONNECTION_ID = 100
 
 
 @pytest.fixture
@@ -83,10 +83,10 @@ def globals_instance(log_mock, settings_manager_mock, hass_mock, fm_client_mock)
 def reset_solar_panels_constant():
     """Reset module-level FM/SOLAR state around each test."""
     c.SOLAR_PANELS = []
-    c.FM_MAIN_CONNECTION_ASSET_ID = _FM_MAIN_CONNECTION_ID
+    c.FM_MAINS_CONNECTION_ASSET_ID = _FM_MAINS_CONNECTION_ID
     yield
     c.SOLAR_PANELS = []
-    c.FM_MAIN_CONNECTION_ASSET_ID = None
+    c.FM_MAINS_CONNECTION_ASSET_ID = None
 
 
 def _valid_panel_payload(**overrides):
@@ -1001,7 +1001,7 @@ class TestSolarPanelValidation:
 
 class TestSolarPanelFMProvisioningCalls:
     """The save handler invokes ensure_asset / ensure_sensor with the
-    correct arguments per the design (asset under Main Connection, sensor
+    correct arguments per the design (asset under Mains Connection, sensor
     named ``Power`` in kW), and reuses the same asset name on update so
     the FM side stays idempotent.
     """
@@ -1019,7 +1019,7 @@ class TestSolarPanelFMProvisioningCalls:
         fm_client_mock.ensure_asset.assert_called_once_with(
             name="South",
             generic_asset_type="solar",
-            parent_asset_id=_FM_MAIN_CONNECTION_ID,
+            parent_asset_id=_FM_MAINS_CONNECTION_ID,
             attributes={
                 "peak_power_wp": 4000,
                 "connected_to_phase": None,
@@ -1167,12 +1167,12 @@ class TestSolarPanelFMProvisioningBlocking:
         assert "FlexMeasures is not connected" in call.kwargs["fm_error"]
 
     @pytest.mark.asyncio
-    async def test_main_connection_missing_returns_fm_error(
+    async def test_mains_connection_missing_returns_fm_error(
         self, globals_instance, fm_client_mock, settings_manager_mock, hass_mock
     ):
         """Grid not yet provisioned → fm_error, no FM calls, no persist."""
         c.GRID_PHASES = 1
-        c.FM_MAIN_CONNECTION_ASSET_ID = None  # override autouse default
+        c.FM_MAINS_CONNECTION_ASSET_ID = None  # override autouse default
 
         await globals_instance._V2GLibertyGlobals__save_solar_panel(
             "event", _valid_panel_payload(), {}


### PR DESCRIPTION
"Mains" (the electrical supply) is the correct British-English term for the grid connection. Rename the FM asset name used in provisioning/lookup and the internal FM_MAINS_CONNECTION_ASSET_ID constant accordingly, plus the affected tests. The existing accounts' assets are renamed on the FlexMeasures side separately.