### PR TITLE
Fix wrong range in "battery at max SoC" notification after restart

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#___)
+- 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#469)
 
 ### Added
 

--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -1,10 +1,10 @@
 # What's changed?
 
-## 0.8.2 2026-06-19
+## 0.8.3 2026-07-??
 
 ### Fixed
 
-- 🪲 BUG: Handle float values from the total power sensor in the load balancer (#465, thanks @sin7ek)
+- 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#___)
 
 ### Added
 
@@ -12,11 +12,11 @@
 
 ### Changed
 
-- 🛠️ Refactor: Rename FlexMeasures "Main Connection" asset to "Mains Connection" (#466)
+-
 
 #### Removing
 
-- ?
+-
 
 ## Complete changelog of all releases
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -7,7 +7,7 @@ That file also contains possible changes that the next release might include.
 
 ### Fixed
 
-- 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#___)
+- 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#469)
 
 ## 0.8.2 2026-06-19
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -3,6 +3,12 @@
 A separate [changelog for only the current release](CHANGELOG.md) is available to keep things readable.
 That file also contains possible changes that the next release might include.
 
+## 0.8.3 2026-07-??
+
+### Fixed
+
+- 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#___)
+
 ## 0.8.2 2026-06-19
 
 ### Fixed

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -996,8 +996,14 @@ class V2Gliberty:
             )
 
         if (
-            await self.evse_client_app.is_charging()
+            # Only on a genuine rise to max SoC, not on the first reading after a
+            # restart (old_soc is then None/"unavailable"). This also avoids
+            # computing the range before the car settings are loaded, which would
+            # use the default battery capacity and report a wrong range.
+            isinstance(old_soc, (int, float))
+            and old_soc < new_soc
             and new_soc == c.CAR_MAX_SOC_IN_PERCENT
+            and await self.evse_client_app.is_charging()
         ):
             message = (
                 f"Car battery at {new_soc} %, "

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_max_soc_notification.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_max_soc_notification.py
@@ -1,0 +1,90 @@
+"""Unit tests for the "battery reached max SoC" notification gate.
+
+The notification must only fire on a genuine rise to the max-SoC setting while
+charging — not on the first SoC reading after a restart (when ``old_soc`` is not
+yet a valid previous value). That restart case would otherwise compute the range
+before the car settings are loaded, reporting a wrong range based on the default
+battery capacity.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from apps.v2g_liberty.main_app import V2Gliberty
+from apps.v2g_liberty import constants as c
+
+
+@pytest.fixture
+def v2g():
+    """Create V2Gliberty with mocked dependencies for SoC-change handling."""
+    hass = AsyncMock()
+    hass.log = MagicMock()
+
+    notifier = MagicMock()
+    notifier.notify_user = AsyncMock()
+
+    instance = V2Gliberty(hass=hass, event_bus=MagicMock(), notifier=notifier)
+
+    # Short-circuit the schedule-refresh branch so the test focuses on the
+    # notification gate only.
+    instance.set_next_action = AsyncMock()
+    instance.soc_at_last_schedule_refresh = c.CAR_MAX_SOC_IN_PERCENT
+
+    instance.evse_client_app = MagicMock()
+    instance.evse_client_app.is_charging = AsyncMock(return_value=True)
+    instance.evse_client_app.get_car_remaining_range = AsyncMock(return_value=278)
+
+    return instance
+
+
+async def _handle(instance, new_soc, old_soc):
+    """Invoke the name-mangled private SoC-change handler."""
+    await instance._V2Gliberty__handle_soc_change(new_soc=new_soc, old_soc=old_soc)
+
+
+class TestMaxSocNotification:
+    @pytest.mark.asyncio
+    async def test_notifies_on_genuine_rise_to_max_soc(self, v2g):
+        """old_soc < max → new_soc == max while charging → one notification."""
+        await _handle(
+            v2g,
+            new_soc=c.CAR_MAX_SOC_IN_PERCENT,
+            old_soc=c.CAR_MAX_SOC_IN_PERCENT - 1,
+        )
+
+        v2g.notifier.notify_user.assert_awaited_once()
+        # The range from get_car_remaining_range and the max-SoC value must be in
+        # the message. The message uses a narrow no-break space before the unit,
+        # so assert on the number and unit separately rather than on a literal
+        # space.
+        message = v2g.notifier.notify_user.await_args.kwargs["message"]
+        assert "278" in message
+        assert str(c.CAR_MAX_SOC_IN_PERCENT) in message
+        assert "%" in message
+
+    @pytest.mark.asyncio
+    async def test_no_notification_on_first_reading_after_restart(self, v2g):
+        """old_soc is not a valid previous value → no notification."""
+        await _handle(v2g, new_soc=c.CAR_MAX_SOC_IN_PERCENT, old_soc="unavailable")
+        v2g.notifier.notify_user.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_notification_when_already_at_max(self, v2g):
+        """No genuine rise (old_soc == new_soc == max) → no notification."""
+        await _handle(
+            v2g,
+            new_soc=c.CAR_MAX_SOC_IN_PERCENT,
+            old_soc=c.CAR_MAX_SOC_IN_PERCENT,
+        )
+        v2g.notifier.notify_user.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_notification_when_not_charging(self, v2g):
+        """Reached max SoC but not charging → no notification."""
+        v2g.evse_client_app.is_charging = AsyncMock(return_value=False)
+        await _handle(
+            v2g,
+            new_soc=c.CAR_MAX_SOC_IN_PERCENT,
+            old_soc=c.CAR_MAX_SOC_IN_PERCENT - 1,
+        )
+        v2g.notifier.notify_user.assert_not_awaited()


### PR DESCRIPTION
The "Car battery at max SoC" notification could fire on the first SoC reading after a restart, when the car was already at the max-SoC setting. At that point the car settings (battery capacity) may not have been loaded yet, so the range was computed with the default capacity and reported a wrong value (e.g. 110 km instead of 278 km).

Only send the notification on a genuine rise to the max-SoC setting while charging: require old_soc to be a valid numeric previous value and lower than new_soc. This skips the initial post-restart reading and guarantees the range is computed after the settings are loaded.

Add unit tests covering the genuine-rise, post-restart, already-at-max and not-charging cases, all derived from CAR_MAX_SOC_IN_PERCENT so they follow the setting rather than a hardcoded value.