### PR TITLE
Live reregister grid listeners

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - 🚀 FEAT: Warn negative grid power (#472)
+- 🚀 FEAT: Live reregister grid listeners (#473)
 
 ### Changed
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -14,6 +14,7 @@ That file also contains possible changes that the next release might include.
 ### Added
 
 - 🚀 FEAT: Warn negative grid power (#472)
+- 🚀 FEAT: Live reregister grid listeners (#473)
 
 ## 0.8.2 2026-06-19
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/data_monitor.py
@@ -157,6 +157,9 @@ class DataMonitor:
             "charge_power_change", self._process_power_change
         )
         self.event_bus.add_event_listener("soc_change", self._process_soc_change)
+        self.event_bus.add_event_listener(
+            "grid_settings_changed", self._on_grid_settings_changed
+        )
 
         # Reservation logging
         if self.reservations_client is not None:
@@ -419,29 +422,66 @@ class DataMonitor:
         # negative reading, so the warning fires once per channel per session.
         if not hasattr(self, "_grid_negative_warned"):
             self._grid_negative_warned = {}
+        # Handles of the registered listeners, kept so they can be cancelled and
+        # re-registered when grid settings change (see _on_grid_settings_changed).
+        if not hasattr(self, "_grid_listener_handles"):
+            self._grid_listener_handles = []
 
         for i, entity_id in enumerate(c.GRID_CONSUMPTION_ENTITIES, start=1):
             self._grid_consumption_scales[i] = await self._get_power_scale(entity_id)
             tracker = PowerTracker()
             tracker.reset(local_now)
             self._grid_consumption_trackers[i] = tracker
-            await self.hass.listen_state(
+            handle = await self.hass.listen_state(
                 self._handle_grid_consumption_change, entity_id, phase=i
             )
+            self._grid_listener_handles.append(handle)
 
         for i, entity_id in enumerate(c.GRID_PRODUCTION_ENTITIES, start=1):
             self._grid_production_scales[i] = await self._get_power_scale(entity_id)
             tracker = PowerTracker()
             tracker.reset(local_now)
             self._grid_production_trackers[i] = tracker
-            await self.hass.listen_state(
+            handle = await self.hass.listen_state(
                 self._handle_grid_production_change, entity_id, phase=i
             )
+            self._grid_listener_handles.append(handle)
 
         self.__log(
             f"Grid monitoring started: {len(c.GRID_CONSUMPTION_ENTITIES)} "
             f"consumption + {len(c.GRID_PRODUCTION_ENTITIES)} production entities."
         )
+
+    async def _teardown_grid_listeners(self):
+        """Cancel the registered grid listeners and reset grid state.
+
+        Leaves the trackers/scales empty so a subsequent _setup_grid_listeners
+        rebuilds them for the new entities.
+        """
+        for handle in getattr(self, "_grid_listener_handles", []):
+            try:
+                await self.hass.cancel_listen_state(handle)
+            except Exception as e:
+                self.__log(f"Failed to cancel a grid listener: {e}", level="WARNING")
+        self._grid_listener_handles = []
+        self._grid_consumption_trackers = {}
+        self._grid_production_trackers = {}
+        self._grid_consumption_scales = {}
+        self._grid_production_scales = {}
+        # Re-arm negative warnings for the freshly (re)configured sensors.
+        self._grid_negative_warned = {}
+
+    async def _on_grid_settings_changed(self, *args, **kwargs):
+        """Re-register grid listeners after grid settings were saved.
+
+        Grid settings changes only update the c.GRID_* constants; the listeners
+        still point at the old entities. Tear them down and register on the new
+        entities so monitoring (and the negative-value warning) works without an
+        app restart.
+        """
+        self.__log("Grid settings changed, re-registering grid listeners.")
+        await self._teardown_grid_listeners()
+        await self._setup_grid_listeners(get_local_now())
 
     async def _handle_grid_consumption_change(
         self, entity, attribute, old, new, kwargs

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/event_bus.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/event_bus.py
@@ -109,6 +109,16 @@ class EventBus(AsyncIOEventEmitter):
           simulation over repaired/imported rows.
         - **Emitted by** data_repairer
 
+    #### Settings related
+
+    - `grid_settings_changed`:
+        - **Description**: Emitted after grid connection settings were saved
+          successfully (consumption/production entities or phases changed).
+          Used by data_monitor to tear down and re-register its grid listeners
+          on the new entities without an app restart. Listeners read the new
+          `c.GRID_*` constants directly, so no arguments are passed.
+        - **Emitted by** v2g_globals
+
     """
 
     def __init__(self, hass: Hass):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
@@ -45,7 +45,7 @@ class V2GLibertyApp(Hass):
         self._log_init_time("Notifier", start_module)
 
         start_module = datetime.now()
-        v2g_globals = V2GLibertyGlobals(self, notifier=notifier)
+        v2g_globals = V2GLibertyGlobals(self, notifier=notifier, event_bus=event_bus)
         self._log_init_time("V2GLibertyGlobals", start_module)
 
         start_module = datetime.now()

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_globals.py
@@ -293,10 +293,12 @@ class V2GLibertyGlobals:
 
     hass: Hass = None
     notifier: Notifier = None
+    event_bus = None
 
-    def __init__(self, hass: Hass, notifier: Notifier):
+    def __init__(self, hass: Hass, notifier: Notifier, event_bus=None):
         self.hass = hass
         self.notifier = notifier
+        self.event_bus = event_bus
         self.__log = get_class_method_logger(module_name="v2g_globals")
         self.v2g_settings = SettingsManager(log=self.__log)
 
@@ -657,6 +659,11 @@ class V2GLibertyGlobals:
             )
             self.__initialise_charger_phase_settings()
             self.__log("Cleared charger phase (grid phases or entities changed)")
+
+        # Let data_monitor re-register its grid listeners on the new entities
+        # without an app restart.
+        if self.event_bus is not None:
+            self.event_bus.emit_event("grid_settings_changed")
 
         self.hass.fire_event("save_grid_connection_settings.result")
 

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_monitor.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_data_monitor.py
@@ -42,6 +42,7 @@ def hass():
     mock_hass.listen_state = AsyncMock()
     mock_hass.run_every = AsyncMock()
     mock_hass.call_service = AsyncMock()
+    mock_hass.cancel_listen_state = AsyncMock()
     return mock_hass
 
 
@@ -853,6 +854,61 @@ class TestGridNegativeWarning:
         )
 
         hass.call_service.assert_not_called()
+
+
+class TestGridSettingsChanged:
+    """Grid listeners are re-registered live when grid settings change."""
+
+    @pytest.mark.asyncio
+    async def test_setup_stores_listener_handles(self, monitor):
+        monitor._grid_consumption_trackers = {}
+        monitor._grid_production_trackers = {}
+        monitor._grid_listener_handles = []
+        c.GRID_CONSUMPTION_ENTITIES = ["sensor.cons_l1"]
+        c.GRID_PRODUCTION_ENTITIES = ["sensor.prod_l1"]
+
+        await monitor._setup_grid_listeners(TEST_NOW)
+
+        # One handle per registered listener (1 consumption + 1 production).
+        assert len(monitor._grid_listener_handles) == 2
+
+    @pytest.mark.asyncio
+    async def test_settings_change_cancels_old_and_registers_new(self, monitor, hass):
+        monitor._grid_consumption_trackers = {}
+        monitor._grid_production_trackers = {}
+        monitor._grid_listener_handles = []
+        c.GRID_CONSUMPTION_ENTITIES = ["sensor.cons_l1"]
+        c.GRID_PRODUCTION_ENTITIES = ["sensor.prod_l1"]
+        await monitor._setup_grid_listeners(TEST_NOW)
+        assert len(monitor._grid_listener_handles) == 2
+
+        # Settings change to a 2-phase set of new entities.
+        c.GRID_CONSUMPTION_ENTITIES = ["sensor.new_cons_l1", "sensor.new_cons_l2"]
+        c.GRID_PRODUCTION_ENTITIES = ["sensor.new_prod_l1", "sensor.new_prod_l2"]
+        hass.listen_state.reset_mock()
+        hass.cancel_listen_state.reset_mock()
+
+        await monitor._on_grid_settings_changed()
+
+        # Old two listeners cancelled, new four registered.
+        assert hass.cancel_listen_state.call_count == 2
+        assert hass.listen_state.call_count == 4
+        assert len(monitor._grid_listener_handles) == 4
+
+    @pytest.mark.asyncio
+    async def test_settings_change_rearms_negative_warning(self, monitor):
+        monitor._grid_consumption_trackers = {}
+        monitor._grid_production_trackers = {}
+        monitor._grid_listener_handles = []
+        c.GRID_CONSUMPTION_ENTITIES = ["sensor.cons_l1"]
+        c.GRID_PRODUCTION_ENTITIES = []
+        await monitor._setup_grid_listeners(TEST_NOW)
+        monitor._grid_negative_warned[("consumption", 1)] = True
+
+        await monitor._on_grid_settings_changed()
+
+        # The warned-flags are cleared so a newly configured wrong sensor warns.
+        assert monitor._grid_negative_warned == {}
 
 
 class TestConcludeGridInterval:

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_v2g_globals_grid_settings.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_v2g_globals_grid_settings.py
@@ -56,6 +56,7 @@ def globals_instance(log_mock, settings_manager_mock, hass_mock, fm_client_mock)
     instance.v2g_settings = settings_manager_mock
     instance.hass = hass_mock
     instance.fm_client_app = fm_client_mock
+    instance.event_bus = MagicMock()
     return instance
 
 
@@ -181,6 +182,24 @@ class TestSaveGridConnectionSettings:
             ("grid_connection", data),
         )
         assert c.GRID_PHASES == 3
+
+    @pytest.mark.asyncio
+    async def test_save_emits_grid_settings_changed(self, globals_with_fm):
+        """A successful save signals data_monitor to re-register listeners."""
+        data = {
+            "phases": 1,
+            "capacity_per_phase": 40,
+            "consumption_entities": ["sensor.grid_cons_l1"],
+            "production_entities": ["sensor.grid_prod_l1"],
+        }
+
+        await globals_with_fm._V2GLibertyGlobals__save_grid_connection_settings(
+            "event", data, {}
+        )
+
+        globals_with_fm.event_bus.emit_event.assert_called_once_with(
+            "grid_settings_changed"
+        )
 
     @pytest.mark.asyncio
     async def test_save_invalid_phases(
@@ -316,6 +335,8 @@ class TestSaveGridConnectionBlocking:
         settings_manager_mock.store_object.assert_not_called()
         assert self._snapshot() == before
         self._assert_fm_error(hass_mock)
+        # No re-registration signal on the FM-error (blocked) path.
+        globals_with_fm.event_bus.emit_event.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ensure_sensor_exception_blocks_save(
@@ -872,6 +893,7 @@ def globals_with_fm(log_mock, settings_manager_mock, hass_mock, fm_client_connec
     instance.v2g_settings = settings_manager_mock
     instance.hass = hass_mock
     instance.fm_client_app = fm_client_connected
+    instance.event_bus = MagicMock()
     return instance
 
 


### PR DESCRIPTION
## Summary

Grid connection settings changes now take effect immediately — no app restart needed. Previously, `DataMonitor` registered its grid listeners only once at startup, so after a user changed the grid sensors, the app kept monitoring the old entities (or none) until it was restarted.

## Background

`DataMonitor._setup_grid_listeners()` was only ever called from `initialize()`. Saving new grid connection settings updated the `c.GRID_*` constants and provisioned the FlexMeasures assets, but never told `DataMonitor` — so the newly selected sensors were not monitored, and any data sent to FlexMeasures kept coming from the old entities, until a restart.

This also affected the negative-value warning added in #472: the runtime persistent notification only fired after a restart for a newly configured wrong/net sensor. With this change it fires as soon as the new sensor reports a negative value.

## Changes

- **`event_bus.py`** — document a new `grid_settings_changed` event (emitted by `v2g_globals`).
- **`v2g_globals.py` / `v2g_app.py`** — pass the `event_bus` into `V2GLibertyGlobals`; emit `grid_settings_changed` after a successful grid settings save (not on the FM-error/blocked path).
- **`data_monitor.py`** — keep the `listen_state` handles; add `_teardown_grid_listeners()` (cancel the listeners, reset the trackers/scales, and re-arm the negative-value warning) and `_on_grid_settings_changed()` (tear down, then re-register on the new entities); subscribe to the event in `initialize()`.

Scope note: only the grid listeners are re-registered. The residential-load calculation reads `c.GRID_PHASES` / `c.SOLAR_PANELS` / `c.CHARGER_CONNECTED_TO_PHASE` live at interval conclusion, so those pick up changes automatically. PV listeners bind to `SOLAR_PANELS` (not grid entities) and are out of scope; re-registering them on a solar-panel settings change is a possible follow-up.

## Testing

- New unit tests: listener handles are stored on setup; a settings change cancels the old listeners and registers on the new entities; the negative-warning flags are cleared; and the save handler emits `grid_settings_changed` on success but not on the FM-error path.
- Full suite green (936 tests), ruff clean (the three pre-existing `F841` warnings in `v2g_app.py` are unrelated).
- Verified end-to-end in the dev app: after saving a changed grid sensor, the log shows `_on_grid_settings_changed > Grid settings changed, re-registering grid listeners.` and monitoring switches to the new sensor without a restart.
