### PR TITLE
Add charger emulator dev tool + charger-driver regression net

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/appdaemon.devcontainer.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/appdaemon.devcontainer.yaml
@@ -21,7 +21,7 @@ appdaemon:
     - util
     - utils
 
-  production_mode: False
+  production_mode: True
   plugins:
     HASS:
       type: hass
@@ -33,6 +33,10 @@ logs:
     filename: /config/logs/v2g_liberty_main.log
   error_log:
     filename: /config/logs/v2g_liberty_error.log
+  # Dev-only: dedicated log for the charger emulator (dev_tools.charger_emulator).
+  charger_emulator_log:
+    name: charger_emulator
+    filename: /config/logs/charger_emulator.log
 
 http:
   url: http://127.0.0.1:5050

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/README.md
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/README.md
@@ -125,7 +125,7 @@ Pick a scenario and connect/disconnect the car via `input_select.emulator_charge
 |--------|-------------|
 | `normal` | Follows V2G's setpoint; SoC ramps. |
 | `reduced_max_power` | Hardware max limited to 3700 W. |
-| `wrong_fingerprint` | A wrong charger identity (unknown charger). |
+| `wrong_fingerprint` | Wrong charger signature (firmware = 0); the 359 connection test flags it (`not_recognised`), dev only shows it. Charger fingerprint, not car-ID recognition. |
 | `error_state` | Charger error (state 7); held > 60 s → un-recoverable. |
 | `internal_error` | A non-zero internal error register. |
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/README.md
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/README.md
@@ -80,3 +80,64 @@ If you do want it on a pre-production host, you can add it by hand — and it no
 No `appdaemon.yaml` edit is needed: `dev_tools` is no longer listed under `exclude_dirs`, so AppDaemon discovers `/config/apps/dev_tools/apps.yaml` once the folder is present. (On a normal install the folder isn't there, so nothing is loaded.)
 
 > ⚠️ **Never place the emulator on a real production install** — it would emit fake meter/PV data.
+
+## Charger Emulator
+
+`charger_emulator.py` — Makes the static Wallbox Quasar Modbus mock (`quasar-mock`) **dynamic**, so V2G Liberty sees a charger that responds to its commands. This unblocks automatic charger-phase detection and lets charging, discharging, SoC and error handling be tested without real hardware.
+
+### What it does
+
+Acts as a **second Modbus client** to the mock and, every tick, mirrors V2G's setpoint onto the report registers:
+
+- **Power mirror** — reads the requested power (register 260) and writes the actual power (526) and charger state (537): charging / discharging / paused.
+- **Ramp** — actual power ramps up slowly and down fast, hard-clamped to the hardware max (never above it).
+- **SoC** — integrates power over time into register 538, with a hardware taper at the physical bounds.
+
+It only ever writes the report registers and never touches V2G's command registers `{81, 82, 83, 88, 257, 260}`, so it cannot fight V2G on the shared mock datastore. Per-tick status is logged to a dedicated log, `charger_emulator.log`.
+
+### Configuration
+
+Edit `dev_tools/apps.yaml` (`charger_emulator`):
+
+```yaml
+charger_emulator:
+  module: dev_tools.charger_emulator
+  class: ChargerEmulator
+  charger_host: quasar-mock
+  charger_port: 5020
+  update_interval: 0.5          # tick, seconds
+  soc_speedup: 1.0              # >1 accelerates the SoC ramp for testing
+  ramp_up_seconds: 15           # time to reach full max power (slow)
+  ramp_down_seconds: 2          # time to fall back to zero (fast)
+  power_target_fraction: 0.92   # delivered = this fraction of the requested power
+  battery_capacity_kwh: 58
+  hw_soc_floor_pct: 10
+  hw_soc_ceiling_pct: 97
+  hw_max_charge_power_w: 5600
+  hw_max_discharge_power_w: 5600
+```
+
+### Scenarios and controls
+
+Pick a scenario and connect/disconnect the car via `input_select.emulator_charger_scenario` and `input_boolean.emulator_car_connected`. With the dev package + dashboard (`homeassistant/packages/dev_tools/`) these are interactive; otherwise change them in Developer Tools → States. A disconnect→connect triggers V2G's automatic phase detection and a fresh SoC read.
+
+| Scenario | Simulates |
+|--------|-------------|
+| `normal` | Follows V2G's setpoint; SoC ramps. |
+| `reduced_max_power` | Hardware max limited to 3700 W. |
+| `wrong_fingerprint` | A wrong charger identity (unknown charger). |
+| `error_state` | Charger error (state 7); held > 60 s → un-recoverable. |
+| `internal_error` | A non-zero internal error register. |
+
+### Crash / no-connection scenarios (container control)
+
+Two failure modes are genuine communication losses that **cannot** be faked with registers — they need control of the mock **container**. Run these from `.devcontainer/` (where the compose file lives), or use `docker pause`/`stop` with the container name from `docker ps`:
+
+| Scenario | Command | Effect | Restore |
+|--------|-------------|--------|---------|
+| **Hung charger** (comms lost) | `docker compose pause quasar-mock` | Modbus stops responding; V2G's reads time out. | `docker compose unpause quasar-mock` |
+| **No connection** | `docker compose stop quasar-mock` | TCP refused; V2G cannot connect. | `docker compose start quasar-mock` |
+
+V2G reacts by flagging communication loss (the `charger_communication_state_change` event) and, after persistent failure, its un-recoverable-error handling. Restoring the container clears it (communication restored). Watch `v2g_liberty_main.log` for the transition.
+
+> ⚠️ **Dev-only** — like the grid/PV emulator, `charger_emulator.py` is stripped from the built add-on image.

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/apps.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/apps.yaml
@@ -29,7 +29,11 @@ charger_emulator:
   charger_host: quasar-mock
   charger_port: 5020
   update_interval: 0.5
-  soc_speedup: 1.0
+
+  # Multiplication factor of how much faster the SoC is updated than in real life.
+  # This is used to speed up the emulator for testing. Normal = 1, fast is 30.
+  soc_speedup: 1
+
   status_log_seconds: 10
   ramp_up_seconds: 15
   ramp_down_seconds: 2

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/apps.yaml
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/apps.yaml
@@ -17,3 +17,25 @@ grid_pv_emulator:
     l2: 300
     l3: 300
   fuse_threshold: 25
+
+# Dev-only: Wallbox Quasar charger emulator.
+# Acts as a second Modbus client to the static mock so it responds to V2G's
+# setpoint (unblocks phase detection, charge/discharge, SoC). Stripped from the
+# production image with the rest of dev_tools (Dockerfile rm).
+charger_emulator:
+  module: dev_tools.charger_emulator
+  class: ChargerEmulator
+  log: charger_emulator_log
+  charger_host: quasar-mock
+  charger_port: 5020
+  update_interval: 0.5
+  soc_speedup: 1.0
+  status_log_seconds: 10
+  ramp_up_seconds: 15
+  ramp_down_seconds: 2
+  power_target_fraction: 0.92
+  battery_capacity_kwh: 58
+  hw_soc_floor_pct: 10
+  hw_soc_ceiling_pct: 97
+  hw_max_charge_power_w: 5600
+  hw_max_discharge_power_w: 5600

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_emulator.py
@@ -123,36 +123,51 @@ class ChargerEmulator(hass.Hass):
         self._ticks_since_status = 0
         self._last_logged_state = None
 
-        # Control surface. These virtual entities are changed via Developer
-        # Tools > States (they are not backed by the input_* integration).
-        self.set_state(
-            self._SCENARIO_ENTITY,
-            state=DEFAULT_SCENARIO,
-            attributes={
-                "options": list(SCENARIOS),
-                "friendly_name": "Charger emulator scenario",
-            },
-        )
-        self.set_state(
-            self._CONNECT_ENTITY,
-            state="on",
-            attributes={"friendly_name": "Charger emulator: car connected"},
-        )
+        # Control surface: prefer real HA input entities (from the dev package,
+        # interactive in the dev dashboard); fall back to virtual set_state
+        # entities (changed via Developer Tools > States) when absent.
+        await self._init_control_entities()
         self.listen_state(self._on_scenario_change, self._SCENARIO_ENTITY)
         self.listen_state(self._on_connect_change, self._CONNECT_ENTITY)
 
         # Resume from the mock's current SoC so an app reload/restart doesn't
         # jump the SoC back to the default (the mock keeps register 538).
         await self._resume_soc_from_mock()
-        await self._apply_scenario(DEFAULT_SCENARIO)
+        await self._apply_scenario(self._scenario.name)
         self._task = asyncio.create_task(self._run_loop())
         self.log(
             f"Charger emulator started against {self._host}:{self._port} "
-            f"(tick {self._interval}s, scenario '{DEFAULT_SCENARIO}')"
+            f"(tick {self._interval}s, scenario '{self._scenario.name}')"
         )
 
     def terminate(self):
         self._running = False
+
+    async def _init_control_entities(self):
+        """Adopt the scenario/connect HA input entities if present (dev package),
+        else create virtual fallbacks so the emulator still works standalone."""
+        scenario = await self.get_state(self._SCENARIO_ENTITY)
+        if scenario not in SCENARIOS:
+            scenario = DEFAULT_SCENARIO
+            self.set_state(
+                self._SCENARIO_ENTITY,
+                state=scenario,
+                attributes={
+                    "options": list(SCENARIOS),
+                    "friendly_name": "Charger emulator scenario",
+                },
+            )
+        self._scenario = SCENARIOS[scenario]
+
+        connected = await self.get_state(self._CONNECT_ENTITY)
+        if connected not in ("on", "off"):
+            connected = "on"
+            self.set_state(
+                self._CONNECT_ENTITY,
+                state=connected,
+                attributes={"friendly_name": "Charger emulator: car connected"},
+            )
+        self._car_connected = connected == "on"
 
     # --- Control-surface callbacks ----------------------------------------
     async def _on_scenario_change(self, entity, attribute, old, new, kwargs):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_emulator.py
@@ -80,6 +80,7 @@ class ChargerEmulator(hass.Hass):
 
     _SCENARIO_ENTITY = "input_select.emulator_charger_scenario"
     _CONNECT_ENTITY = "input_boolean.emulator_car_connected"
+    _SOC_ENTITY = "input_number.emulator_soc"
 
     async def initialize(self):
         self.log("")
@@ -122,6 +123,7 @@ class ChargerEmulator(hass.Hass):
         )
         self._ticks_since_status = 0
         self._last_logged_state = None
+        self._last_soc_shown = None
 
         # Control surface: prefer real HA input entities (from the dev package,
         # interactive in the dev dashboard); fall back to virtual set_state
@@ -129,15 +131,22 @@ class ChargerEmulator(hass.Hass):
         await self._init_control_entities()
         self.listen_state(self._on_scenario_change, self._SCENARIO_ENTITY)
         self.listen_state(self._on_connect_change, self._CONNECT_ENTITY)
+        self.listen_state(self._on_soc_set, self._SOC_ENTITY)
 
         # Resume from the mock's current SoC so an app reload/restart doesn't
         # jump the SoC back to the default (the mock keeps register 538).
         await self._resume_soc_from_mock()
         await self._apply_scenario(self._scenario.name)
+        await self._sync_soc_entity()
         self._task = asyncio.create_task(self._run_loop())
         self.log(
             f"Charger emulator started against {self._host}:{self._port} "
-            f"(tick {self._interval}s, scenario '{self._scenario.name}')"
+            f"(tick {self._interval}s, scenario '{self._scenario.name}', "
+            f"soc_speedup {self._soc_speedup}x, "
+            f"ramp up/down {self._ramp_up_seconds}/{self._ramp_down_seconds}s, "
+            f"target {self._power_target_fraction}, "
+            f"max {self._profile.hw_max_charge_power_w}W, "
+            f"battery {self._profile.battery_capacity_kwh}kWh)"
         )
 
     def terminate(self):
@@ -178,6 +187,35 @@ class ChargerEmulator(hass.Hass):
     async def _on_connect_change(self, entity, attribute, old, new, kwargs):
         self._car_connected = new == "on"
         self.log(f"Charger emulator car connected -> {self._car_connected}")
+
+    async def _on_soc_set(self, entity, attribute, old, new, kwargs):
+        """Jump the emulated SoC to a value set via input_number.emulator_soc."""
+        try:
+            value = float(new)
+        except (TypeError, ValueError):
+            return
+        # Ignore our own echo (the tick pushes the live SoC onto this entity).
+        if abs(value - self._soc) < 1.0:
+            return
+        self._soc = value
+        self._last_soc_shown = round(value)
+        self.log(f"Charger emulator SoC set to {round(self._soc)}%")
+
+    async def _sync_soc_entity(self):
+        """Reflect the current SoC on input_number.emulator_soc so the slider
+        tracks it. Only writes on a changed (rounded) value to limit churn."""
+        rounded = round(self._soc)
+        if rounded == self._last_soc_shown:
+            return
+        self._last_soc_shown = rounded
+        try:
+            await self.call_service(
+                "input_number/set_value",
+                entity_id=self._SOC_ENTITY,
+                value=rounded,
+            )
+        except Exception as e:  # noqa: BLE001 - entity absent without the dev package
+            self.log(f"Could not sync SoC entity: {e}", level="DEBUG")
 
     # --- Scenario activation ----------------------------------------------
     async def _apply_scenario(self, name: str):
@@ -267,6 +305,7 @@ class ChargerEmulator(hass.Hass):
                 REG_SOC: round(self._soc),
             }
         )
+        await self._sync_soc_entity()
         self._log_status(state, setpoint, actual)
 
     def _log_status(self, state: int, setpoint: int, actual: int):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_emulator.py
@@ -1,0 +1,375 @@
+"""Wallbox Quasar charger emulator for the dev environment.
+
+Makes the static Quasar mock (``quasar-mock:5020``) dynamic by acting as a
+second Modbus client to it: every tick it reads the command registers V2G
+Liberty writes (setpoint 260, action 257, control 81) and writes back
+realistic report registers (actual power 526, state 537, SoC 538, errors
+539-542, identity 1-3, max power 514). This unblocks automatic charger-phase
+detection and lets scenarios be played without real hardware.
+
+Producer/consumer with V2G (strict): the emulator writes ONLY report registers
+and never touches V2G's command registers {81, 82, 83, 88, 257, 260}. Because
+the mock uses one shared datastore, a write there would clobber V2G's control.
+
+Control surface (create-once HA entities, change via Developer Tools > States):
+- ``input_select.emulator_charger_scenario`` — pick a scenario.
+- ``input_boolean.emulator_car_connected`` — connect/disconnect the car.
+
+Dev-only: this app is not included in the production Docker image.
+"""
+
+import asyncio
+import random
+from dataclasses import replace
+
+import appdaemon.plugins.hass.hassapi as hass
+import pymodbus.client as modbus_client
+from pymodbus.exceptions import ModbusException
+
+from dev_tools.charger_scenarios import (
+    DEFAULT_SCENARIO,
+    EMULATOR_WRITE_REGISTERS,
+    QUASAR_1,
+    REG_ACTION,
+    REG_ACTUAL_POWER,
+    REG_ERROR_1,
+    REG_ERROR_2,
+    REG_ERROR_3,
+    REG_ERROR_4,
+    REG_FIRMWARE,
+    REG_LOCKED,
+    REG_MAX_POWER,
+    REG_SERIAL_HIGH,
+    REG_SERIAL_LOW,
+    REG_SETPOINT,
+    REG_SOC,
+    REG_STATE,
+    SCENARIOS,
+    STATE_CHARGING,
+    STATE_DISCHARGING,
+    STATE_DISCONNECTED,
+    STATE_PAUSED,
+    STATE_WAITING,
+    int16_to_uint16,
+    uint16_to_int16,
+)
+
+_STOP_ACTION = 2
+
+# Profile fields that can be overridden from apps.yaml.
+_PROFILE_ARGS = (
+    "hw_max_charge_power_w",
+    "hw_max_discharge_power_w",
+    "hw_soc_floor_pct",
+    "hw_soc_ceiling_pct",
+    "battery_capacity_kwh",
+    "power_jitter_w",
+)
+
+_STATE_NAMES = {
+    STATE_DISCONNECTED: "disconnected",
+    STATE_CHARGING: "charging",
+    STATE_WAITING: "waiting",
+    STATE_PAUSED: "paused",
+    STATE_DISCHARGING: "discharging",
+}
+
+
+class ChargerEmulator(hass.Hass):
+    """AppDaemon dev app that drives the static Quasar mock dynamically."""
+
+    _SCENARIO_ENTITY = "input_select.emulator_charger_scenario"
+    _CONNECT_ENTITY = "input_boolean.emulator_car_connected"
+
+    async def initialize(self):
+        self.log("")
+        self.log(
+            "#################### CHARGER EMULATOR (RE)STARTED ####################"
+        )
+        self._host = self.args.get("charger_host", "quasar-mock")
+        self._port = int(self.args.get("charger_port", 5020))
+        self._interval = float(self.args.get("update_interval", 0.5))
+        # Accelerate the SoC ramp for testing (1.0 = real time).
+        self._soc_speedup = float(self.args.get("soc_speedup", 1.0))
+        # Power ramp (asymmetric): increasing the magnitude is slow
+        # (ramp_up_seconds to go full-scale), decreasing toward zero is fast
+        # (ramp_down_seconds). The delivered power settles at this fraction of the
+        # requested power and is hard-clamped so it never exceeds the hardware max.
+        self._ramp_up_seconds = float(self.args.get("ramp_up_seconds", 15))
+        self._ramp_down_seconds = float(self.args.get("ramp_down_seconds", 2))
+        self._power_target_fraction = float(
+            self.args.get("power_target_fraction", 0.92)
+        )
+        self._actual_power = 0.0
+
+        profile_kwargs = {k: self.args[k] for k in _PROFILE_ARGS if k in self.args}
+        self._base_profile = replace(QUASAR_1, **profile_kwargs)
+
+        self._client = None
+        self._running = True
+        self._connection_ok = None  # tri-state, to log transitions only
+        self._car_connected = True
+        self._scenario = SCENARIOS[DEFAULT_SCENARIO]
+        self._profile = self._base_profile
+        self._soc = float(self._scenario.start_soc)
+
+        # Throttled status heartbeat to the emulator log (0 = off).
+        self._status_log_seconds = float(self.args.get("status_log_seconds", 10))
+        self._status_every = (
+            max(1, round(self._status_log_seconds / self._interval))
+            if self._status_log_seconds > 0
+            else 0
+        )
+        self._ticks_since_status = 0
+        self._last_logged_state = None
+
+        # Control surface. These virtual entities are changed via Developer
+        # Tools > States (they are not backed by the input_* integration).
+        self.set_state(
+            self._SCENARIO_ENTITY,
+            state=DEFAULT_SCENARIO,
+            attributes={
+                "options": list(SCENARIOS),
+                "friendly_name": "Charger emulator scenario",
+            },
+        )
+        self.set_state(
+            self._CONNECT_ENTITY,
+            state="on",
+            attributes={"friendly_name": "Charger emulator: car connected"},
+        )
+        self.listen_state(self._on_scenario_change, self._SCENARIO_ENTITY)
+        self.listen_state(self._on_connect_change, self._CONNECT_ENTITY)
+
+        # Resume from the mock's current SoC so an app reload/restart doesn't
+        # jump the SoC back to the default (the mock keeps register 538).
+        await self._resume_soc_from_mock()
+        await self._apply_scenario(DEFAULT_SCENARIO)
+        self._task = asyncio.create_task(self._run_loop())
+        self.log(
+            f"Charger emulator started against {self._host}:{self._port} "
+            f"(tick {self._interval}s, scenario '{DEFAULT_SCENARIO}')"
+        )
+
+    def terminate(self):
+        self._running = False
+
+    # --- Control-surface callbacks ----------------------------------------
+    async def _on_scenario_change(self, entity, attribute, old, new, kwargs):
+        if new in SCENARIOS:
+            self.log(f"Charger emulator scenario -> '{new}'")
+            await self._apply_scenario(new)
+
+    async def _on_connect_change(self, entity, attribute, old, new, kwargs):
+        self._car_connected = new == "on"
+        self.log(f"Charger emulator car connected -> {self._car_connected}")
+
+    # --- Scenario activation ----------------------------------------------
+    async def _apply_scenario(self, name: str):
+        self._scenario = SCENARIOS[name]
+        self._profile = replace(self._base_profile, **self._scenario.profile_overrides)
+        self._actual_power = 0.0
+
+        if not await self._ensure_connected():
+            return
+
+        seed = {
+            REG_LOCKED: 0,
+            REG_MAX_POWER: self._profile.hw_max_charge_power_w,
+            REG_FIRMWARE: self._profile.firmware,
+            REG_SERIAL_HIGH: self._profile.serial_high,
+            REG_SERIAL_LOW: self._profile.serial_low,
+            REG_ERROR_1: 0,
+            REG_ERROR_2: 0,
+            REG_ERROR_3: 0,
+            REG_ERROR_4: 0,
+        }
+        if self._scenario.mirror and self._car_connected:
+            seed[REG_STATE] = STATE_PAUSED
+            seed[REG_ACTUAL_POWER] = 0
+            seed[REG_SOC] = round(self._soc)
+        elif self._scenario.mirror:
+            seed[REG_STATE] = STATE_DISCONNECTED
+            seed[REG_ACTUAL_POWER] = 0
+            seed[REG_SOC] = 0
+        else:
+            seed[REG_STATE] = STATE_PAUSED
+            seed[REG_ACTUAL_POWER] = 0
+            seed[REG_SOC] = round(self._soc)
+
+        # Scenario-specific overrides (error state/register, wrong identity) win.
+        seed.update(self._scenario.registers)
+        await self._write_many(seed)
+
+    async def _resume_soc_from_mock(self):
+        """Adopt the mock's current SoC (register 538) if it is a valid value,
+        so a hot reload or restart continues instead of resetting to the default.
+        """
+        if not await self._ensure_connected():
+            return
+        raw = await self._read(REG_SOC)
+        if raw is not None and 2 <= raw <= 97:
+            self._soc = float(raw)
+
+    # --- Tick loop --------------------------------------------------------
+    async def _run_loop(self):
+        while self._running:
+            try:
+                await self._tick()
+            except Exception as e:  # noqa: BLE001 - dev tool: keep the loop alive
+                self.log(f"Charger emulator tick error: {e}", level="WARNING")
+            await asyncio.sleep(self._interval)
+
+    async def _tick(self):
+        if not await self._ensure_connected():
+            return
+        # Frozen scenarios hold the registers seeded on activation.
+        if not self._scenario.mirror:
+            return
+
+        if not self._car_connected:
+            self._actual_power = 0.0
+            await self._write_many(
+                {REG_STATE: STATE_DISCONNECTED, REG_ACTUAL_POWER: 0, REG_SOC: 0}
+            )
+            self._log_status(STATE_DISCONNECTED, 0, 0)
+            return
+
+        raw_setpoint = await self._read(REG_SETPOINT)
+        action = await self._read(REG_ACTION)
+        if raw_setpoint is None or action is None:
+            return
+        setpoint = uint16_to_int16(raw_setpoint)
+
+        state, requested = self._derive_state_and_power(setpoint, action)
+        actual = self._ramp_power(requested)
+        self._integrate_soc(actual)
+
+        await self._write_many(
+            {
+                REG_ACTUAL_POWER: int16_to_uint16(actual),
+                REG_STATE: state,
+                REG_SOC: round(self._soc),
+            }
+        )
+        self._log_status(state, setpoint, actual)
+
+    def _log_status(self, state: int, setpoint: int, actual: int):
+        """Log a throttled status line: on state change or every N seconds."""
+        if self._status_every == 0:
+            return
+        self._ticks_since_status += 1
+        if (
+            state != self._last_logged_state
+            or self._ticks_since_status >= self._status_every
+        ):
+            self._ticks_since_status = 0
+            self._last_logged_state = state
+            name = _STATE_NAMES.get(state, str(state))
+            self.log(
+                f"status: state={name} setpoint={setpoint}W actual={actual}W "
+                f"soc={round(self._soc)}%"
+            )
+
+    def _derive_state_and_power(self, setpoint: int, action: int):
+        p = self._profile
+        if action == _STOP_ACTION or setpoint == 0:
+            return STATE_PAUSED, 0
+        if setpoint > 0:
+            target = min(setpoint, p.hw_max_charge_power_w)
+            if self._soc >= p.hw_soc_ceiling_pct:  # full: taper off
+                return STATE_WAITING, 0
+            return STATE_CHARGING, target
+        target = max(setpoint, -p.hw_max_discharge_power_w)
+        if self._soc <= p.hw_soc_floor_pct:  # empty: taper off
+            return STATE_WAITING, 0
+        return STATE_DISCHARGING, target
+
+    def _ramp_power(self, requested: int) -> int:
+        """Ramp the delivered power toward a fraction of the requested power.
+
+        Increasing the magnitude (drawing/feeding more) is slow — takes
+        ``ramp_up_seconds`` to cover the full range; decreasing toward zero is
+        fast (``ramp_down_seconds``). Applies to every power change, not just a
+        cold start. Varies slightly around the target and is hard-clamped to the
+        hardware max so it never exceeds it.
+        """
+        p = self._profile
+        target = self._power_target_fraction * requested
+        if target != 0:
+            target += random.uniform(-p.power_jitter_w, p.power_jitter_w)
+
+        cur = self._actual_power
+        if cur == 0:
+            increasing = target != 0
+        elif (cur > 0) == (target > 0):  # same direction
+            increasing = abs(target) > abs(cur)
+        else:  # crossing zero: first head back toward zero
+            increasing = False
+        ramp_seconds = self._ramp_up_seconds if increasing else self._ramp_down_seconds
+
+        max_step = p.hw_max_charge_power_w * self._interval / ramp_seconds
+        delta = target - cur
+        self._actual_power = cur + max(-max_step, min(max_step, delta))
+        self._actual_power = max(
+            -p.hw_max_discharge_power_w,
+            min(p.hw_max_charge_power_w, self._actual_power),
+        )
+        return round(self._actual_power)
+
+    def _integrate_soc(self, actual_power_w: int):
+        p = self._profile
+        dt_hours = self._interval * self._soc_speedup / 3600.0
+        self._soc += (
+            actual_power_w * dt_hours / (p.battery_capacity_kwh * 1000.0) * 100.0
+        )
+        self._soc = min(max(self._soc, p.hw_soc_floor_pct), p.hw_soc_ceiling_pct)
+
+    # --- Modbus helpers ---------------------------------------------------
+    async def _ensure_connected(self) -> bool:
+        if self._client is None:
+            self._client = modbus_client.AsyncModbusTcpClient(
+                host=self._host, port=self._port, timeout=3
+            )
+        if not self._client.connected:
+            try:
+                await self._client.connect()
+            except (ModbusException, OSError) as e:
+                self._log_connection(False, str(e))
+                return False
+        ok = self._client.connected
+        self._log_connection(ok)
+        return ok
+
+    def _log_connection(self, ok: bool, detail: str = ""):
+        if ok != self._connection_ok:
+            self._connection_ok = ok
+            if ok:
+                self.log(f"Charger emulator connected to {self._host}:{self._port}")
+            else:
+                self.log(
+                    f"Charger emulator lost connection to {self._host}:{self._port} {detail}",
+                    level="WARNING",
+                )
+
+    async def _read(self, address: int):
+        try:
+            result = await self._client.read_holding_registers(
+                address=address, count=1, device_id=1
+            )
+        except (ModbusException, OSError):
+            return None
+        if result is None or result.isError():
+            return None
+        return result.registers[0]
+
+    async def _write_many(self, registers: dict[int, int]):
+        for address, value in registers.items():
+            await self._write(address, value)
+
+    async def _write(self, address: int, value: int):
+        if address not in EMULATOR_WRITE_REGISTERS:
+            raise ValueError(f"Emulator may not write command register {address}")
+        await self._client.write_register(
+            address=address, value=int(value) & 0xFFFF, device_id=1
+        )

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_scenarios.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_scenarios.py
@@ -140,8 +140,12 @@ SCENARIOS: dict[str, ChargerScenario] = {
     ),
     "wrong_fingerprint": ChargerScenario(
         name="wrong_fingerprint",
-        description="Normal mirror but wrong identity (registers 1-3) — an unknown charger.",
-        registers={REG_FIRMWARE: 9999, REG_SERIAL_HIGH: 0, REG_SERIAL_LOW: 0},
+        description=(
+            "Wrong charger signature (firmware register = 0). The 359 connection "
+            "test flags it (test_connection -> not_recognised); dev does not "
+            "validate it. This is the charger fingerprint, not car-ID recognition."
+        ),
+        registers={REG_FIRMWARE: 0, REG_SERIAL_HIGH: 0, REG_SERIAL_LOW: 0},
     ),
     "reduced_max_power": ChargerScenario(
         name="reduced_max_power",

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_scenarios.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/charger_scenarios.py
@@ -1,0 +1,168 @@
+"""Charger scenarios and device profile for the dev charger emulator.
+
+Pure data — no Home Assistant, pymodbus or AppDaemon imports — so this module
+is importable by both the dev emulator (``dev_tools.charger_emulator``) and by
+pytest, which can drive the same scenarios against a fake Modbus client to
+assert the real ``modbus_evse_client`` behaviour.
+
+Register addresses, state codes and the signed-power encoding mirror the real
+Wallbox Quasar driver (``v2g_liberty/modbus_evse_client.py``) and the static
+mock (``charger-mocks/quasar``).
+
+Dev-only: not part of the production add-on.
+"""
+
+from dataclasses import dataclass, field
+
+# --- Wallbox Quasar register addresses -------------------------------------
+# Registers V2G Liberty WRITES (the emulator only reads these):
+REG_CONTROL = 81  # 1 = remote (V2G in control)
+REG_ACTION = 257  # 1 = start, 2 = stop
+REG_SETPOINT = 260  # requested power, signed W
+
+# Registers V2G Liberty READS (the emulator writes these):
+REG_FIRMWARE = 1
+REG_SERIAL_HIGH = 2
+REG_SERIAL_LOW = 3
+REG_LOCKED = 256  # 0 = unlocked
+REG_MAX_POWER = 514  # max available power, W
+REG_ACTUAL_POWER = 526  # actual power, signed W
+REG_STATE = 537  # charger state (see below)
+REG_SOC = 538  # state of charge, %
+REG_ERROR_1 = 539
+REG_ERROR_2 = 540
+REG_ERROR_3 = 541
+REG_ERROR_4 = 542
+
+# The emulator may ONLY write these report registers. It must never write V2G's
+# command registers {81, 82, 83, 88, 257, 260}: on the shared mock datastore
+# that would clobber V2G's own control/action/setpoint.
+EMULATOR_WRITE_REGISTERS = frozenset(
+    {
+        REG_FIRMWARE,
+        REG_SERIAL_HIGH,
+        REG_SERIAL_LOW,
+        REG_LOCKED,
+        REG_MAX_POWER,
+        REG_ACTUAL_POWER,
+        REG_STATE,
+        REG_SOC,
+        REG_ERROR_1,
+        REG_ERROR_2,
+        REG_ERROR_3,
+        REG_ERROR_4,
+    }
+)
+
+# --- Charger state codes (register 537) ------------------------------------
+STATE_DISCONNECTED = 0
+STATE_CHARGING = 1
+STATE_WAITING = 2  # connected, waiting for car demand
+STATE_PAUSED = 4  # connected, not charging
+STATE_LOCKED = 6
+STATE_ERROR = 7
+STATE_DISCHARGING = 11
+
+# --- Signed-power (two's complement) encoding ------------------------------
+_MAX_UNSIGNED_SHORT = 65536
+
+
+def int16_to_uint16(value: int) -> int:
+    """Encode a signed value as an unsigned 16-bit Modbus register value."""
+    return value + _MAX_UNSIGNED_SHORT if value < 0 else value
+
+
+def uint16_to_int16(value: int) -> int:
+    """Decode an unsigned 16-bit Modbus register value as a signed value."""
+    return value - _MAX_UNSIGNED_SHORT if value > _MAX_UNSIGNED_SHORT // 2 else value
+
+
+# --- Charger device profile ------------------------------------------------
+@dataclass
+class ChargerProfile:  # pylint: disable=too-many-instance-attributes
+    """Hardware constants the physical charger/car enforces.
+
+    Independent of V2G Liberty's user settings (min/max SoC, capacity) — the
+    point is to test whether V2G respects its own limits. The SoC floor/ceiling
+    are behavioural (there is no such register): the emulator freezes the SoC
+    and tapers power to zero at these bounds. ``hw_max_*_power_w`` surfaces on
+    register 514, the identity fields on registers 1-3.
+
+    Keep ``hw_soc_floor_pct`` >= 2: the driver treats a polled SoC of 0/1 as
+    'unavailable', not as a real low battery.
+    """
+
+    hw_max_charge_power_w: int = 5600
+    hw_max_discharge_power_w: int = 5600
+    hw_soc_floor_pct: float = 10.0
+    hw_soc_ceiling_pct: float = 97.0
+    battery_capacity_kwh: float = 58.0
+    firmware: int = 3400
+    serial_high: int = 5
+    serial_low: int = 19659
+    power_jitter_w: int = 50
+
+
+QUASAR_1 = ChargerProfile()
+
+
+# --- Scenarios -------------------------------------------------------------
+@dataclass
+class ChargerScenario:
+    """A selectable emulator scenario.
+
+    ``mirror=True`` (dynamic): each tick the emulator derives the state and
+    actual power from V2G's setpoint (register 260) and ramps the SoC — normal
+    operation. ``mirror=False`` (frozen): the emulator holds ``registers`` as
+    seeded and does not run the mirror — used for error/fault scenarios.
+
+    ``registers`` are extra raw uint16 values written on activation (a forced
+    error state, a non-zero error register, a wrong identity). They win over
+    the seeded defaults. ``profile_overrides`` tweak the device profile for
+    this scenario only (e.g. a reduced or invalid max power).
+    """
+
+    name: str
+    description: str
+    mirror: bool = True
+    start_soc: int = 33
+    registers: dict[int, int] = field(default_factory=dict)
+    profile_overrides: dict = field(default_factory=dict)
+
+
+SCENARIOS: dict[str, ChargerScenario] = {
+    "normal": ChargerScenario(
+        name="normal",
+        description=(
+            "Normal operation: state and power follow V2G's setpoint, SoC ramps. "
+            "Use the car-connected toggle to test connect/disconnect."
+        ),
+    ),
+    "wrong_fingerprint": ChargerScenario(
+        name="wrong_fingerprint",
+        description="Normal mirror but wrong identity (registers 1-3) — an unknown charger.",
+        registers={REG_FIRMWARE: 9999, REG_SERIAL_HIGH: 0, REG_SERIAL_LOW: 0},
+    ),
+    "reduced_max_power": ChargerScenario(
+        name="reduced_max_power",
+        description="Mirror with a reduced hardware max power (register 514 = 3700 W).",
+        profile_overrides={
+            "hw_max_charge_power_w": 3700,
+            "hw_max_discharge_power_w": 3700,
+        },
+    ),
+    "error_state": ChargerScenario(
+        name="error_state",
+        description="Frozen error: state 7, power 0. Held > 60 s triggers un-recoverable handling.",
+        mirror=False,
+        registers={REG_STATE: STATE_ERROR, REG_ACTUAL_POWER: 0},
+    ),
+    "internal_error": ChargerScenario(
+        name="internal_error",
+        description="Frozen internal error: error register 539 non-zero, power 0.",
+        mirror=False,
+        registers={REG_STATE: STATE_PAUSED, REG_ACTUAL_POWER: 0, REG_ERROR_1: 1234},
+    ),
+}
+
+DEFAULT_SCENARIO = "normal"

--- a/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/grid_pv_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/dev_tools/grid_pv_emulator.py
@@ -43,20 +43,21 @@ class GridPvEmulator(hass.Hass):
         self._pv_panels = self.args.get("pv_panels", [])
         self._base_load = self.args.get("base_load", {"l1": 800, "l2": 600, "l3": 400})
 
-        # Create a toggle in HA to pause/resume the emulator
-        self.set_state(
-            self._PAUSE_ENTITY,
-            state="off",
-            attributes={"friendly_name": "Pause grid/PV emulator"},
-        )
-
-        # Toggle to force the emulated net sensors negative on demand, so the
-        # grid dialog's "negative value" warning can be tested at any time.
-        self.set_state(
-            self._FORCE_NEGATIVE_ENTITY,
-            state="off",
-            attributes={"friendly_name": "Force emulator grid net negative"},
-        )
+        # Prefer real HA input entities (dev package) so the toggles are
+        # interactive in the dev dashboard; create virtual fallbacks only when
+        # absent, so the emulator still works standalone.
+        if self.get_state(self._PAUSE_ENTITY) is None:
+            self.set_state(
+                self._PAUSE_ENTITY,
+                state="off",
+                attributes={"friendly_name": "Pause grid/PV emulator"},
+            )
+        if self.get_state(self._FORCE_NEGATIVE_ENTITY) is None:
+            self.set_state(
+                self._FORCE_NEGATIVE_ENTITY,
+                state="off",
+                attributes={"friendly_name": "Force emulator grid net negative"},
+            )
 
         # Create a fuse threshold entity (DSMR OBIS 1-0:31.4.0)
         fuse_threshold = self.args.get("fuse_threshold", 25)

--- a/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/conftest.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/conftest.py
@@ -1,0 +1,9 @@
+"""Make the AppDaemon apps dir importable so ``dev_tools.*`` resolves in pytest,
+exactly as AppDaemon does at runtime (it adds apps/ to the path)."""
+
+import sys
+from pathlib import Path
+
+_APPS = Path(__file__).resolve().parents[2] / "apps"
+if str(_APPS) not in sys.path:
+    sys.path.insert(0, str(_APPS))

--- a/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/test_charger_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/test_charger_emulator.py
@@ -1,0 +1,283 @@
+"""Isolated tests for the dev charger emulator.
+
+Drive the emulator's scenario, mirror, ramp and SoC-taper logic against a fake
+Modbus client (an in-memory register store), without AppDaemon or the mock
+container. The emulator instance is built with ``object.__new__`` so we skip
+``hass.Hass.__init__`` and set only the attributes the logic needs.
+"""
+
+import dataclasses
+from types import SimpleNamespace
+
+import pytest
+
+from dev_tools.charger_emulator import ChargerEmulator
+from dev_tools.charger_scenarios import (
+    QUASAR_1,
+    REG_ACTION,
+    REG_ACTUAL_POWER,
+    REG_ERROR_1,
+    REG_FIRMWARE,
+    REG_MAX_POWER,
+    REG_SERIAL_HIGH,
+    REG_SETPOINT,
+    REG_SOC,
+    REG_STATE,
+    SCENARIOS,
+    STATE_CHARGING,
+    STATE_DISCHARGING,
+    STATE_DISCONNECTED,
+    STATE_ERROR,
+    STATE_PAUSED,
+    STATE_WAITING,
+    int16_to_uint16,
+    uint16_to_int16,
+)
+
+MAX = QUASAR_1.hw_max_charge_power_w  # 5600
+
+
+class FakeModbusClient:
+    """Minimal async pymodbus stand-in backed by an in-memory register store."""
+
+    def __init__(self, store=None):
+        self.store = dict(store or {})
+        self.connected = True
+
+    async def connect(self):
+        self.connected = True
+        return True
+
+    async def read_holding_registers(self, address, count=1, device_id=1):
+        regs = [self.store.get(address + i, 0) for i in range(count)]
+        return SimpleNamespace(registers=regs, isError=lambda: False)
+
+    async def write_register(self, address, value, device_id=1):
+        self.store[address] = value
+        return SimpleNamespace(isError=lambda: False)
+
+    def close(self):
+        pass
+
+
+def make_emulator(fake, **over):
+    e = object.__new__(ChargerEmulator)
+    e.log = lambda *a, **k: None
+    e._client = fake
+    e._host = "test"
+    e._port = 5020
+    e._interval = over.get("interval", 0.5)
+    e._soc_speedup = over.get("soc_speedup", 1.0)
+    e._ramp_up_seconds = over.get("ramp_up_seconds", 15)
+    e._ramp_down_seconds = over.get("ramp_down_seconds", 2)
+    e._power_target_fraction = over.get("power_target_fraction", 0.92)
+    e._actual_power = 0.0
+    e._running = True
+    e._connection_ok = True
+    e._car_connected = over.get("car_connected", True)
+
+    profile = over.get("profile", QUASAR_1)
+    if "power_jitter_w" in over:
+        profile = dataclasses.replace(profile, power_jitter_w=over["power_jitter_w"])
+    e._base_profile = profile
+    e._profile = profile
+    e._scenario = SCENARIOS[over.get("scenario", "normal")]
+    e._soc = float(over.get("soc", 33))
+    e._status_every = 0
+    e._ticks_since_status = 0
+    e._last_logged_state = None
+    return e
+
+
+def _decoded(store, addr):
+    return uint16_to_int16(store.get(addr, 0))
+
+
+# --- encoding (sync) -------------------------------------------------------
+def test_encoding_roundtrip():
+    for v in (-MAX, -1000, -1, 0, 1, 1000, MAX):
+        assert uint16_to_int16(int16_to_uint16(v)) == v
+    assert int16_to_uint16(-1000) == 64536
+
+
+# --- state derivation (sync) -----------------------------------------------
+def test_derive_state_and_power():
+    e = make_emulator(FakeModbusClient())
+    assert e._derive_state_and_power(3000, 1) == (STATE_CHARGING, 3000)
+    assert e._derive_state_and_power(-3000, 1) == (STATE_DISCHARGING, -3000)
+    assert e._derive_state_and_power(0, 1) == (STATE_PAUSED, 0)
+    assert e._derive_state_and_power(3000, 2) == (STATE_PAUSED, 0)  # stop action
+    # requested above hardware max is capped
+    assert e._derive_state_and_power(9999, 1) == (STATE_CHARGING, MAX)
+    assert e._derive_state_and_power(-9999, 1) == (STATE_DISCHARGING, -MAX)
+
+
+def test_derive_taper_at_soc_limits():
+    full = make_emulator(FakeModbusClient(), soc=QUASAR_1.hw_soc_ceiling_pct)
+    assert full._derive_state_and_power(5000, 1) == (STATE_WAITING, 0)
+    empty = make_emulator(FakeModbusClient(), soc=QUASAR_1.hw_soc_floor_pct)
+    assert empty._derive_state_and_power(-5000, 1) == (STATE_WAITING, 0)
+
+
+# --- power ramp (sync) -----------------------------------------------------
+def test_ramp_timing_up_slow_down_fast():
+    e = make_emulator(FakeModbusClient(), power_jitter_w=0)
+    target = round(0.92 * MAX)
+
+    up_ticks = 0
+    while round(e._actual_power) < target:
+        e._ramp_power(MAX)
+        up_ticks += 1
+        assert up_ticks < 200
+    # 0 -> 92% of max should take roughly ramp_up_seconds (15 s @ 0.5 s = 30 ticks)
+    assert 24 <= up_ticks <= 34
+
+    down_ticks = 0
+    while round(e._actual_power) > 0:
+        e._ramp_power(0)
+        down_ticks += 1
+        assert down_ticks < 200
+    # down is much faster (2 s @ 0.5 s = 4 ticks)
+    assert down_ticks <= 6
+    assert down_ticks < up_ticks
+
+
+def test_ramp_hard_clamp_never_exceeds_max():
+    # fraction 1.0 + jitter would push above max without the clamp.
+    e = make_emulator(FakeModbusClient(), power_jitter_w=200, power_target_fraction=1.0)
+    peak = max(e._ramp_power(MAX) for _ in range(200))
+    assert peak <= MAX
+    e2 = make_emulator(
+        FakeModbusClient(), power_jitter_w=200, power_target_fraction=1.0
+    )
+    trough = min(e2._ramp_power(-MAX) for _ in range(200))
+    assert trough >= -MAX
+
+
+# --- mirror tick (async) ---------------------------------------------------
+@pytest.mark.asyncio
+async def test_mirror_tick_charging_follows_setpoint():
+    fake = FakeModbusClient({REG_SETPOINT: 5600, REG_ACTION: 1})
+    e = make_emulator(fake, power_jitter_w=0)
+    for _ in range(40):
+        await e._tick()
+    assert fake.store[REG_STATE] == STATE_CHARGING
+    actual = _decoded(fake.store, REG_ACTUAL_POWER)
+    assert 0 < actual <= MAX
+    assert abs(actual - round(0.92 * MAX)) <= 5  # settled at ~92%
+    # command registers must be left untouched by the emulator
+    assert fake.store[REG_SETPOINT] == 5600
+    assert fake.store[REG_ACTION] == 1
+
+
+@pytest.mark.asyncio
+async def test_mirror_tick_discharging():
+    fake = FakeModbusClient({REG_SETPOINT: int16_to_uint16(-5600), REG_ACTION: 1})
+    e = make_emulator(fake, power_jitter_w=0)
+    for _ in range(40):
+        await e._tick()
+    assert fake.store[REG_STATE] == STATE_DISCHARGING
+    actual = _decoded(fake.store, REG_ACTUAL_POWER)
+    assert -MAX <= actual < 0
+
+
+@pytest.mark.asyncio
+async def test_mirror_tick_paused_when_setpoint_zero():
+    fake = FakeModbusClient({REG_SETPOINT: 0, REG_ACTION: 1})
+    e = make_emulator(fake)
+    await e._tick()
+    assert fake.store[REG_STATE] == STATE_PAUSED
+    assert _decoded(fake.store, REG_ACTUAL_POWER) == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnected_tick_writes_zero_state():
+    fake = FakeModbusClient({REG_SETPOINT: 5600, REG_ACTION: 1})
+    e = make_emulator(fake, car_connected=False)
+    await e._tick()
+    assert fake.store[REG_STATE] == STATE_DISCONNECTED
+    assert fake.store[REG_ACTUAL_POWER] == 0
+    assert fake.store[REG_SOC] == 0
+
+
+@pytest.mark.asyncio
+async def test_soc_ramps_up_while_charging():
+    fake = FakeModbusClient({REG_SETPOINT: 5600, REG_ACTION: 1})
+    e = make_emulator(fake, power_jitter_w=0, soc_speedup=100, soc=50)
+    for _ in range(60):
+        await e._tick()
+    assert e._soc > 50
+    assert e._soc <= QUASAR_1.hw_soc_ceiling_pct
+
+
+# --- disjoint write guard (async) ------------------------------------------
+@pytest.mark.asyncio
+async def test_write_guard_rejects_command_registers():
+    e = make_emulator(FakeModbusClient())
+    for cmd in (REG_SETPOINT, REG_ACTION, 81, 82, 83, 88):
+        with pytest.raises(ValueError):
+            await e._write(cmd, 1)
+    # report registers are allowed
+    await e._write(REG_ACTUAL_POWER, 100)
+
+
+# --- scenarios (async) -----------------------------------------------------
+@pytest.mark.asyncio
+async def test_scenario_error_state():
+    fake = FakeModbusClient()
+    e = make_emulator(fake)
+    await e._apply_scenario("error_state")
+    assert fake.store[REG_STATE] == STATE_ERROR
+    assert fake.store[REG_ACTUAL_POWER] == 0
+    # frozen: a tick must not overwrite the error state back to charging
+    fake.store[REG_SETPOINT] = 5600
+    fake.store[REG_ACTION] = 1
+    await e._tick()
+    assert fake.store[REG_STATE] == STATE_ERROR
+
+
+@pytest.mark.asyncio
+async def test_scenario_internal_error():
+    fake = FakeModbusClient()
+    e = make_emulator(fake)
+    await e._apply_scenario("internal_error")
+    assert fake.store[REG_ERROR_1] == 1234
+    assert fake.store[REG_ACTUAL_POWER] == 0
+
+
+@pytest.mark.asyncio
+async def test_scenario_wrong_fingerprint():
+    fake = FakeModbusClient()
+    e = make_emulator(fake)
+    await e._apply_scenario("wrong_fingerprint")
+    assert fake.store[REG_FIRMWARE] == 9999
+    assert fake.store[REG_SERIAL_HIGH] == 0
+
+
+@pytest.mark.asyncio
+async def test_scenario_reduced_max_power_caps_delivery():
+    fake = FakeModbusClient({REG_SETPOINT: 5600, REG_ACTION: 1})
+    e = make_emulator(fake, power_jitter_w=0)
+    await e._apply_scenario("reduced_max_power")
+    assert fake.store[REG_MAX_POWER] == 3700
+    for _ in range(60):
+        await e._tick()
+    actual = _decoded(fake.store, REG_ACTUAL_POWER)
+    assert actual <= 3700
+
+
+# --- resume SoC (async) ----------------------------------------------------
+@pytest.mark.asyncio
+async def test_resume_soc_from_mock_adopts_valid_value():
+    fake = FakeModbusClient({REG_SOC: 50})
+    e = make_emulator(fake, soc=33)
+    await e._resume_soc_from_mock()
+    assert e._soc == 50.0
+
+
+@pytest.mark.asyncio
+async def test_resume_soc_ignores_invalid_value():
+    fake = FakeModbusClient({REG_SOC: 0})  # 0 = idle/unavailable, not a real SoC
+    e = make_emulator(fake, soc=33)
+    await e._resume_soc_from_mock()
+    assert e._soc == 33.0

--- a/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/test_charger_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/test_charger_emulator.py
@@ -251,7 +251,7 @@ async def test_scenario_wrong_fingerprint():
     fake = FakeModbusClient()
     e = make_emulator(fake)
     await e._apply_scenario("wrong_fingerprint")
-    assert fake.store[REG_FIRMWARE] == 9999
+    assert fake.store[REG_FIRMWARE] == 0
     assert fake.store[REG_SERIAL_HIGH] == 0
 
 

--- a/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/test_charger_emulator.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/dev_tools/test_charger_emulator.py
@@ -86,6 +86,7 @@ def make_emulator(fake, **over):
     e._status_every = 0
     e._ticks_since_status = 0
     e._last_logged_state = None
+    e._last_soc_shown = None
     return e
 
 

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_modbus_evse_client_scenarios.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_modbus_evse_client_scenarios.py
@@ -1,0 +1,264 @@
+"""Regression net for the charger driver's decode -> entity/event pipeline.
+
+Drives the real ``modbus_evse_client`` with scenario register states (via a fake
+Modbus client) and asserts the observable contract: the event_bus events it
+emits and the entity values it caches. This pins the current behaviour so the
+359 refactor (MBR/MCE dataclasses, EV split) can be verified to preserve it.
+
+Heavy side-effect methods (the SoC-refresh dance, poll-strategy timers, charger
+actions, error notifications) are patched so the tests focus on the decode/event
+surface — the part that must survive the rewrite unchanged. Assert on that
+boundary (events + cached entity values), not on the patched internals: that is
+what keeps this net green across the refactor.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apps.dev_tools.charger_scenarios import (
+    REG_ACTUAL_POWER,
+    REG_ERROR_1,
+    REG_SOC,
+    REG_STATE,
+    STATE_CHARGING,
+    STATE_DISCONNECTED,
+    STATE_PAUSED,
+    int16_to_uint16,
+)
+from apps.v2g_liberty.event_bus import EventBus
+from apps.v2g_liberty.modbus_evse_client import ModbusEVSEclient
+
+_EVENTS = [
+    "soc_change",
+    "remaining_range_change",
+    "charge_power_change",
+    "charger_state_change",
+    "is_car_connected",
+    "evse_polled",
+    "update_charger_info",
+    "charger_communication_state_change",
+]
+
+
+class FakeModbusClient:
+    def __init__(self, store=None):
+        self.store = dict(store or {})
+        self.connected = True
+
+    async def connect(self):
+        self.connected = True
+        return True
+
+    async def read_holding_registers(self, address, count=1, device_id=1):
+        regs = [self.store.get(address + i, 0) for i in range(count)]
+        return SimpleNamespace(registers=regs, isError=lambda: False)
+
+    async def write_register(self, address, value, device_id=1):
+        self.store[address] = value
+        return SimpleNamespace(isError=lambda: False)
+
+    def close(self):
+        pass
+
+
+class Recorder:
+    def __init__(self):
+        self.events = []
+
+    def subscribe(self, bus):
+        for name in _EVENTS:
+            bus.add_event_listener(name, self._make(name))
+
+    def _make(self, name):
+        def rec(*args, **kwargs):
+            self.events.append((name, kwargs))
+
+        return rec
+
+    def find(self, name):
+        return [kw for n, kw in self.events if n == name]
+
+
+@pytest.fixture
+def driver():
+    hass = MagicMock()
+    for m in ("set_state", "run_every", "run_in", "get_state", "cancel_timer"):
+        setattr(hass, m, AsyncMock())
+    bus = EventBus(hass)
+    rec = Recorder()
+    rec.subscribe(bus)
+
+    e = ModbusEVSEclient(hass, bus, MagicMock())
+    e.notifier = MagicMock()
+    e.v2g_main_app = MagicMock()
+    e.client = FakeModbusClient()
+    e._am_i_active = True
+    e.modbus_exception_counter = 0
+    e.requested_charge_power = 0
+    e._is_power_deviating = False
+    e.try_get_new_soc_in_process = False
+
+    # Reset the shared (class-level) entity caches to a clean baseline.
+    for ent in (
+        e.ENTITY_CHARGER_CURRENT_POWER,
+        e.ENTITY_CHARGER_STATE,
+        e.ENTITY_CAR_SOC,
+        e.ENTITY_ERROR_1,
+        e.ENTITY_ERROR_2,
+        e.ENTITY_ERROR_3,
+        e.ENTITY_ERROR_4,
+        e.ENTITY_CHARGER_LOCKED,
+    ):
+        ent["current_value"] = None
+
+    # Patch the heavy side-effects so the tests exercise the decode/event path
+    # without real charger I/O, timers or notifications. What each one does:
+    #  - __set_charger_action: writes a start/stop command to the charger.
+    #  - __set_poll_strategy: cancels/(re)schedules the poll timer (AppDaemon).
+    #  - __get_car_soc: the 1 W "SoC-refresh dance" (start -> read 538 -> stop).
+    #  - __handle_charger_error_state_change: user notifications + grace timers.
+    #  - get_car_remaining_range: range calc that needs runtime constants.
+    e._ModbusEVSEclient__set_charger_action = AsyncMock()
+    e._ModbusEVSEclient__set_poll_strategy = AsyncMock()
+    e._ModbusEVSEclient__get_car_soc = AsyncMock(return_value=50)
+    e._ModbusEVSEclient__handle_charger_error_state_change = AsyncMock()
+    e.get_car_remaining_range = AsyncMock(return_value=100)
+
+    return e, rec
+
+
+def _process(e, entities):
+    return e._ModbusEVSEclient__get_and_process_registers(entities)
+
+
+def _update(e, entity, value):
+    return e._ModbusEVSEclient__update_evse_entity(entity, value)
+
+
+def _modbus_read(e, address, length):
+    return e._ModbusEVSEclient__modbus_read(address, length)
+
+
+def _base_poll(e):
+    return e._ModbusEVSEclient__base_polling({})
+
+
+# --- decode ----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_modbus_read_decodes_twos_complement(driver):
+    e, _ = driver
+    e.client.store[REG_ACTUAL_POWER] = int16_to_uint16(-1000)
+    assert await _modbus_read(e, REG_ACTUAL_POWER, 1) == [-1000]
+
+
+# --- single-entity event contract ------------------------------------------
+@pytest.mark.asyncio
+async def test_power_change_emits_event_and_caches_value(driver):
+    e, rec = driver
+    await _update(e, e.ENTITY_CHARGER_CURRENT_POWER, 4000)
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] == 4000
+    assert rec.find("charge_power_change")[-1]["new_power"] == 4000
+    await _update(e, e.ENTITY_CHARGER_CURRENT_POWER, -2000)
+    assert rec.find("charge_power_change")[-1]["new_power"] == -2000
+
+
+@pytest.mark.asyncio
+async def test_soc_change_emits_events(driver):
+    e, rec = driver
+    e.ENTITY_CAR_SOC["current_value"] = 50
+    await _update(e, e.ENTITY_CAR_SOC, 55)
+    assert e.ENTITY_CAR_SOC["current_value"] == 55
+    assert rec.find("soc_change")[-1] == {"new_soc": 55, "old_soc": 50}
+    assert rec.find("remaining_range_change")
+
+
+# --- full poll -------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_full_poll_charging(driver):
+    e, rec = driver
+    e.client.store.update(
+        {REG_ACTUAL_POWER: 4000, REG_STATE: STATE_CHARGING, REG_SOC: 55}
+    )
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] == 4000
+    assert e.ENTITY_CHARGER_STATE["current_value"] == STATE_CHARGING
+    assert e.ENTITY_CAR_SOC["current_value"] == 55
+    assert rec.find("charge_power_change")[-1]["new_power"] == 4000
+    assert rec.find("charger_state_change")[-1]["new_charger_state"] == STATE_CHARGING
+    assert rec.find("soc_change")[-1]["new_soc"] == 55
+    # None -> a connected state means the car just connected
+    assert rec.find("is_car_connected")[-1]["is_car_connected"] is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_marks_soc_unavailable_and_emits_event(driver):
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_CAR_SOC["current_value"] = 55
+    e.client.store.update(
+        {REG_STATE: STATE_DISCONNECTED, REG_ACTUAL_POWER: 0, REG_SOC: 0}
+    )
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+
+    assert rec.find("is_car_connected")[-1]["is_car_connected"] is False
+    assert e.ENTITY_CAR_SOC["current_value"] == "unavailable"
+    e._ModbusEVSEclient__set_charger_action.assert_awaited()  # explicit stop
+
+
+@pytest.mark.asyncio
+async def test_connect_emits_is_car_connected_true(driver):
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_DISCONNECTED
+    e.client.store.update({REG_STATE: STATE_PAUSED, REG_ACTUAL_POWER: 0, REG_SOC: 55})
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+
+    assert rec.find("is_car_connected")[-1]["is_car_connected"] is True
+    assert rec.find("charger_state_change")[-1]["new_charger_state"] == STATE_PAUSED
+
+
+@pytest.mark.asyncio
+async def test_soc_zero_while_connected_is_ignored(driver):
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING  # connected
+    e.ENTITY_CAR_SOC["current_value"] = 50
+    e.client.store.update(
+        {REG_STATE: STATE_CHARGING, REG_SOC: 0, REG_ACTUAL_POWER: 3000}
+    )
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+
+    # A polled 0 while connected is a glitch: keep the last value, no event.
+    assert e.ENTITY_CAR_SOC["current_value"] == 50
+    assert not rec.find("soc_change")
+
+
+@pytest.mark.asyncio
+async def test_error_register_invokes_error_handler(driver):
+    e, _ = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_CHARGER_CURRENT_POWER["current_value"] = 3000
+    e.ENTITY_CAR_SOC["current_value"] = 55
+    e.ENTITY_ERROR_1["current_value"] = 0
+    e.client.store.update(
+        {
+            REG_ACTUAL_POWER: 3000,
+            REG_STATE: STATE_CHARGING,
+            REG_SOC: 55,
+            REG_ERROR_1: 1234,
+        }
+    )
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+    e._ModbusEVSEclient__handle_charger_error_state_change.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_base_polling_emits_evse_polled(driver):
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.client.store.update(
+        {REG_ACTUAL_POWER: 3000, REG_STATE: STATE_CHARGING, REG_SOC: 55}
+    )
+    await _base_poll(e)
+    assert rec.find("evse_polled")[-1]["stop"] is False

--- a/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/charger_emulator_dev.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/charger_emulator_dev.yaml
@@ -44,3 +44,14 @@ input_boolean:
     name: Force emulator grid net negative
     icon: mdi:transmission-tower-export
     initial: false
+
+input_number:
+  # Jump the emulated SoC to a value (read by charger_emulator).
+  emulator_soc:
+    name: "Charger emulator: set SoC"
+    icon: mdi:battery-charging
+    min: 0
+    max: 100
+    step: 1
+    unit_of_measurement: "%"
+    mode: slider

--- a/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/charger_emulator_dev.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/charger_emulator_dev.yaml
@@ -1,0 +1,46 @@
+# Dev-only: real HA input entities for the charger and grid/PV emulators, so the
+# scenario picker and toggles are interactive in the dev dashboard.
+#
+# Setup (dev environment only):
+#   1. Copy this file AND emulator_dev_dashboard.yaml into your HA config under
+#      packages/dev_tools/.
+#   2. In configuration.yaml, under `homeassistant: packages:` add:
+#        emulator_dev_pack: !include packages/dev_tools/charger_emulator_dev.yaml
+#   3. Register the dashboard: under your existing `lovelace: dashboards:` add:
+#        emulator-dev:
+#          mode: yaml
+#          filename: packages/dev_tools/emulator_dev_dashboard.yaml
+#          title: Emulator (dev)
+#          icon: mdi:test-tube
+#   4. Restart Home Assistant.
+#
+# Without this package the emulator falls back to virtual entities that you
+# change via Developer Tools > States (the options/toggle are then read-only in
+# the dashboard).
+
+input_select:
+  emulator_charger_scenario:
+    name: Charger emulator scenario
+    icon: mdi:ev-station
+    initial: normal
+    options:
+      - normal
+      - wrong_fingerprint
+      - reduced_max_power
+      - error_state
+      - internal_error
+
+input_boolean:
+  emulator_car_connected:
+    name: "Charger emulator: car connected"
+    icon: mdi:car-electric
+    initial: true
+  # Grid / PV emulator toggles (read by grid_pv_emulator).
+  emulator_paused:
+    name: Pause grid/PV emulator
+    icon: mdi:pause
+    initial: false
+  emulator_force_negative:
+    name: Force emulator grid net negative
+    icon: mdi:transmission-tower-export
+    initial: false

--- a/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
@@ -1,0 +1,71 @@
+# Dev-only Lovelace dashboard for the charger + grid/PV emulators.
+# Register it as a separate YAML-mode dashboard (see charger_emulator_dev.yaml).
+title: Emulator (dev)
+views:
+  - title: Charger emulator
+    path: charger-emulator
+    icon: mdi:ev-station
+    cards:
+      - type: markdown
+        content: |
+          ## Charger emulator (dev)
+          Makes the static Wallbox-Quasar mock respond to V2G Liberty, so you can
+          test charging, phase detection and error handling without real hardware.
+
+          **Emulator controls** — drive the emulator:
+          - **Scenario** — what the mock simulates:
+            - `normal`: follows V2G's setpoint (charge/discharge), SoC ramps.
+            - `reduced_max_power`: hardware max limited to 3700 W.
+            - `wrong_fingerprint`: reports a wrong charger identity.
+            - `error_state`: charger error (state 7); held > 60 s → un-recoverable.
+            - `internal_error`: a non-zero internal error register.
+          - **Car connected** — connect/disconnect the car. A disconnect→connect
+            triggers V2G's automatic phase detection and a fresh SoC read.
+
+          **Charger status** — what V2G Liberty reads back from the (emulated)
+          charger: state, actual power, SoC, range, hardware max power and
+          connection status.
+
+          **Grid / PV emulator** — toggles for the separate grid/PV emulator:
+          *Pause* (freeze it) and *Force negative* (make the grid net sensors
+          negative to test the "negative value" warning).
+
+          _Tip: at real speed the SoC moves slowly (~0.2 %/min); raise
+          `soc_speedup` in `dev_tools/apps.yaml` to speed it up. Full tick-by-tick
+          detail is in `charger_emulator.log`._
+
+      - type: entities
+        title: Emulator controls
+        show_header_toggle: false
+        entities:
+          - entity: input_select.emulator_charger_scenario
+            name: Scenario
+          - entity: input_boolean.emulator_car_connected
+            name: Car connected
+
+      - type: entities
+        title: Charger status (as V2G Liberty reads it)
+        entities:
+          - entity: sensor.charger_state_text
+            name: Charger state
+          - entity: sensor.charger_real_charging_power
+            name: Actual power
+          - entity: sensor.car_state_of_charge
+            name: SoC
+          - entity: sensor.car_remaining_range
+            name: Remaining range
+          - entity: sensor.charger_max_available_power
+            name: Max available power
+          - entity: sensor.charger_connection_status
+            name: Connection status
+
+      - type: entities
+        title: Grid / PV emulator
+        show_header_toggle: false
+        entities:
+          - entity: input_boolean.emulator_paused
+            name: Pause grid/PV emulator
+            icon: mdi:pause
+          - entity: input_boolean.emulator_force_negative
+            name: Force grid net negative
+            icon: mdi:transmission-tower-export

--- a/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
@@ -1,8 +1,8 @@
 # Dev-only Lovelace dashboard for the charger + grid/PV emulators.
 # Register it as a separate YAML-mode dashboard (see charger_emulator_dev.yaml).
-title: Emulator (dev)
+title: Emulators
 views:
-  - title: Charger emulator
+  - title: Emulators
     path: charger-emulator
     icon: mdi:ev-station
     cards:
@@ -11,61 +11,68 @@ views:
           ## Charger emulator (dev)
           Makes the static Wallbox-Quasar mock respond to V2G Liberty, so you can
           test charging, phase detection and error handling without real hardware.
+          Full tick-by-tick detail is in `charger_emulator.log`.
 
-          **Emulator controls** — drive the emulator:
-          - **Scenario** — what the mock simulates:
-            - `normal`: follows V2G's setpoint (charge/discharge), SoC ramps.
-            - `reduced_max_power`: hardware max limited to 3700 W.
-            - `wrong_fingerprint`: reports a wrong charger identity.
-            - `error_state`: charger error (state 7); held > 60 s → un-recoverable.
-            - `internal_error`: a non-zero internal error register.
-          - **Car connected** — connect/disconnect the car. A disconnect→connect
-            triggers V2G's automatic phase detection and a fresh SoC read.
+      - type: vertical-stack
+        cards:
+          - type: entities
+            title: Emulator controls
+            show_header_toggle: false
+            entities:
+              - entity: input_select.emulator_charger_scenario
+                name: Scenario
+              - entity: input_boolean.emulator_car_connected
+                name: Car connected
+          - type: markdown
+            content: |
+              **Scenario** — what the mock simulates:
+              - `normal`: follows V2G's setpoint (charge/discharge), SoC ramps.
+              - `reduced_max_power`: hardware max limited to 3700 W.
+              - `wrong_fingerprint`: reports a wrong charger identity.
+              - `error_state`: charger error (state 7); held > 60 s → un-recoverable.
+              - `internal_error`: a non-zero internal error register.
 
-          **Charger status** — what V2G Liberty reads back from the (emulated)
-          charger: state, actual power, SoC, range, hardware max power and
-          connection status.
+              **Car connected** — connect/disconnect the car; a disconnect→connect
+              triggers automatic phase detection and a fresh SoC read.
 
-          **Grid / PV emulator** — toggles for the separate grid/PV emulator:
-          *Pause* (freeze it) and *Force negative* (make the grid net sensors
-          negative to test the "negative value" warning).
+      - type: vertical-stack
+        cards:
+          - type: entities
+            title: Charger status
+            entities:
+              - entity: sensor.charger_state_text
+                name: Charger state
+              - entity: sensor.charger_real_charging_power
+                name: Actual power
+              - entity: sensor.car_state_of_charge
+                name: SoC
+              - entity: sensor.car_remaining_range
+                name: Remaining range
+              - entity: sensor.charger_max_available_power
+                name: Max available power
+              - entity: sensor.charger_connection_status
+                name: Connection status
+          - type: markdown
+            content: |
+              What V2G Liberty reads back from the (emulated) charger.
 
-          _Tip: at real speed the SoC moves slowly (~0.2 %/min); raise
-          `soc_speedup` in `dev_tools/apps.yaml` to speed it up. Full tick-by-tick
-          detail is in `charger_emulator.log`._
+              _Tip: at real speed the SoC moves slowly (~0.2 %/min); raise
+              `soc_speedup` in `dev_tools/apps.yaml` to speed it up._
 
-      - type: entities
-        title: Emulator controls
-        show_header_toggle: false
-        entities:
-          - entity: input_select.emulator_charger_scenario
-            name: Scenario
-          - entity: input_boolean.emulator_car_connected
-            name: Car connected
-
-      - type: entities
-        title: Charger status (as V2G Liberty reads it)
-        entities:
-          - entity: sensor.charger_state_text
-            name: Charger state
-          - entity: sensor.charger_real_charging_power
-            name: Actual power
-          - entity: sensor.car_state_of_charge
-            name: SoC
-          - entity: sensor.car_remaining_range
-            name: Remaining range
-          - entity: sensor.charger_max_available_power
-            name: Max available power
-          - entity: sensor.charger_connection_status
-            name: Connection status
-
-      - type: entities
-        title: Grid / PV emulator
-        show_header_toggle: false
-        entities:
-          - entity: input_boolean.emulator_paused
-            name: Pause grid/PV emulator
-            icon: mdi:pause
-          - entity: input_boolean.emulator_force_negative
-            name: Force grid net negative
-            icon: mdi:transmission-tower-export
+      - type: vertical-stack
+        cards:
+          - type: entities
+            title: Grid / PV emulator
+            show_header_toggle: false
+            entities:
+              - entity: input_boolean.emulator_paused
+                name: Pause grid/PV emulator
+                icon: mdi:pause
+              - entity: input_boolean.emulator_force_negative
+                name: Force grid net negative
+                icon: mdi:transmission-tower-export
+          - type: markdown
+            content: |
+              Toggles for the separate grid/PV emulator: **Pause** (freeze it) and
+              **Force negative** (make the grid net sensors negative to test the
+              "negative value" warning).

--- a/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
@@ -23,6 +23,8 @@ views:
                 name: Scenario
               - entity: input_boolean.emulator_car_connected
                 name: Car connected
+              - entity: input_number.emulator_soc
+                name: Set SoC
           - type: markdown
             content: |
               **Scenario** — what the mock simulates:

--- a/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
+++ b/v2g-liberty/rootfs/root/homeassistant/packages/dev_tools/emulator_dev_dashboard.yaml
@@ -78,3 +78,37 @@ views:
               Toggles for the separate grid/PV emulator: **Pause** (freeze it) and
               **Force negative** (make the grid net sensors negative to test the
               "negative value" warning).
+
+  - title: Test checklist
+    path: test-checklist
+    icon: mdi:clipboard-check
+    cards:
+      - type: markdown
+        content: |
+          ## End-to-end test checklist
+
+          **Setup**
+          - Keep the first tab open (live status + controls).
+          - Watch two logs: `charger_emulator.log` and `v2g_liberty_main.log`.
+          - Speed up the SoC: `soc_speedup: 30` in `dev_tools/apps.yaml` + restart
+            AppDaemon. Use the **Set SoC** slider to jump to a start value.
+
+          **Happy path**
+          1. **Idle** — scenario `normal`, car connected → Connected/paused, 0 W, SoC steady.
+          2. **Phase detection** — car connected off → on → main log: auto-detection succeeds → **L1** (needs the grid/PV emulator + 3 grid sensors).
+          3. **Charge** — mode "Max boost now" → power ramps up (~15 s) to ~5150 W, SoC rises.
+          4. **Discharge** — "Max discharge now" → power negative, SoC falls, clips near own-min (20 %).
+          5. **Pause** — "Stop" → power ramps down fast (~2 s) to 0, paused.
+          6. **SoC ceiling** — charge to 97 % → power tapers to 0, "waiting".
+
+          **Scenarios** (back to `normal` after each)
+          7. `reduced_max_power` → power caps at ~3700 W.
+          8. `wrong_fingerprint` → wrong charger **signature** (firmware = 0). The 359 connection test flags it (`test_connection` → `not_recognised`); on dev it is only shown in the charger info. (Charger fingerprint — not car-ID recognition.)
+          9. `error_state` → status error; after ~60 s → V2G un-recoverable handling.
+          10. `internal_error` → non-zero error register; after ~60 s → un-recoverable.
+
+          **Comms (container control)**
+          11. **Hung charger** — `docker compose pause quasar-mock` → comms-lost (`charger_communication_state_change`); `docker compose unpause quasar-mock` → restored.
+          12. **No connection** — `docker compose stop quasar-mock` → cannot connect; `docker compose start quasar-mock` → reconnects.
+
+          **Reset**: scenario `normal`, car connected on, mode automatic, `soc_speedup` back to 1.


### PR DESCRIPTION
## Summary

Adds a **charger emulator** that makes the static Wallbox Quasar Modbus mock respond to V2G Liberty, so charging, phase detection, SoC and error handling can be tested without real hardware — plus a **regression net** that pins the current charger-driver behaviour, and an interactive dev dashboard to drive it all.

Everything here is **dev-only** (the `dev_tools` apps are stripped from the production image). It prepares the ground for the upcoming `359` charger/EV migration: the emulator is the prerequisite for end-to-end charger testing, and the regression net is that migration's Fase 0 safety net.

## What's included

**Charger emulator** — `dev_tools/charger_emulator.py`, `charger_scenarios.py`
- Second Modbus client to the mock: mirrors V2G's setpoint onto the report registers (actual power, state), with an asymmetric power ramp (slow up, fast down) hard-clamped to the hardware max, and a SoC ramp with a hardware taper.
- Scenarios: `normal`, `reduced_max_power`, `wrong_fingerprint`, `error_state`, `internal_error`; plus connect/disconnect and a manual "Set SoC".
- Crash / no-connection via container control (`docker compose pause`/`stop`), documented in the README.
- A shared, pure-data scenario/profile module reused by both the emulator and pytest.

**Regression net** — `tests/v2g_liberty/test_modbus_evse_client_scenarios.py`
- 9 tests that drive the real `modbus_evse_client` with scenario register states and assert the observable contract (event_bus events + entity values): decode, power/SoC/state changes, connect/disconnect, the SoC-0 glitch, errors and polling. Pins current behaviour so the 359 refactor can be verified to preserve it.

**Interactive dev dashboard** — `homeassistant/packages/dev_tools/`
- A dev HA package with real input entities + a standalone Lovelace dashboard (controls, live charger status, grid/PV toggles, and a "Test checklist" tab). `grid_pv_emulator` now reads the real entities too (virtual fallback).

**Emulator unit tests** — `tests/dev_tools/` — 17 tests (mirror, ramp, taper, scenarios, SoC-resume, disjoint write-set).

## How to use
See `dev_tools/README.md`. In the dev container the emulator loads automatically; to activate the interactive dashboard, copy the two `homeassistant/packages/dev_tools/` files into your HA config, add the package include + dashboard registration and restart HA (details in the package header).

## Review notes
- `appdaemon.devcontainer.yaml` sets **`production_mode: True`** (disables AppDaemon hot-reload for this dev config) — decide whether to keep.
- `dev_tools/apps.yaml` default **`soc_speedup: 30`** (fast SoC ramp for testing).
- The HA dev package + dashboard are committed as **dev-tooling source only** — not activated for end users (a normal install has no `configuration.yaml` entry for them).

**Dev-only** stripped from the production image.
