### PR TITLE
359 fase0 vangnet

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_modbus_evse_client_scenarios.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_modbus_evse_client_scenarios.py
@@ -16,14 +16,19 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pymodbus.exceptions import ModbusException
 
 from apps.dev_tools.charger_scenarios import (
     REG_ACTUAL_POWER,
     REG_ERROR_1,
+    REG_LOCKED,
     REG_SOC,
     REG_STATE,
     STATE_CHARGING,
+    STATE_DISCHARGING,
     STATE_DISCONNECTED,
+    STATE_ERROR,
+    STATE_LOCKED,
     STATE_PAUSED,
     int16_to_uint16,
 )
@@ -46,16 +51,28 @@ class FakeModbusClient:
     def __init__(self, store=None):
         self.store = dict(store or {})
         self.connected = True
+        # Fault injection for the comms-loss tests. The real driver only reacts
+        # to a raised ModbusException (it never inspects isError() and treats a
+        # None/short return as success), so "raise" is the only way to drive the
+        # __handle_modbus_exception path. Default None keeps the base tests green.
+        self.fault = None
 
     async def connect(self):
         self.connected = True
         return True
 
     async def read_holding_registers(self, address, count=1, device_id=1):
+        if self.fault == "raise":
+            raise ModbusException("simulated comms loss")
         regs = [self.store.get(address + i, 0) for i in range(count)]
+        if self.fault == "short" and regs:
+            # Return fewer registers than requested to drive the partial-result path.
+            regs = regs[:-1]
         return SimpleNamespace(registers=regs, isError=lambda: False)
 
     async def write_register(self, address, value, device_id=1):
+        if self.fault == "raise":
+            raise ModbusException("simulated comms loss")
         self.store[address] = value
         return SimpleNamespace(isError=lambda: False)
 
@@ -141,8 +158,45 @@ def _modbus_read(e, address, length):
     return e._ModbusEVSEclient__modbus_read(address, length)
 
 
+def _modbus_write(e, address, value):
+    return e._ModbusEVSEclient__modbus_write(address, value, "test")
+
+
+def _handle_error_state(e, **kw):
+    return e._ModbusEVSEclient__handle_charger_error_state_change(kw)
+
+
 def _base_poll(e):
     return e._ModbusEVSEclient__base_polling({})
+
+
+def _minimal_poll(e):
+    return e._ModbusEVSEclient__minimal_polling({})
+
+
+def _get_soc(e, **kw):
+    return e._ModbusEVSEclient__get_car_soc(**kw)
+
+
+def _force_get(e, address, min_at, max_at, min_after=None, max_after=None):
+    return e._ModbusEVSEclient__force_get_register(
+        address, min_at, max_at, min_after, max_after
+    )
+
+
+def _handle_power(e, new_power):
+    return e._ModbusEVSEclient__handle_charge_power_change(new_power)
+
+
+def _set_poll_strategy(e):
+    # Bypass the fixture's instance-level AsyncMock and run the REAL class method.
+    return ModbusEVSEclient._ModbusEVSEclient__set_poll_strategy(e)
+
+
+def _comm_states(rec):
+    return [
+        kw["can_communicate"] for kw in rec.find("charger_communication_state_change")
+    ]
 
 
 # --- decode ----------------------------------------------------------------
@@ -262,3 +316,565 @@ async def test_base_polling_emits_evse_polled(driver):
     )
     await _base_poll(e)
     assert rec.find("evse_polled")[-1]["stop"] is False
+
+
+# ===========================================================================
+# EXPANDED COVERAGE (Fase 0): the lifecycle paths the base net patches away.
+# These drive the REAL __get_car_soc / __force_get_register, the comms-loss /
+# recovery / un-recoverable escalation, the poll-strategy selection and the
+# power-deviation logic, asserting on the same observable boundary (events +
+# cached entity values + the direct v2g_main_app / notifier calls the driver
+# makes instead of an event). Un-patching is done per-test in the body so the
+# 9 base tests above stay untouched.
+# ===========================================================================
+
+
+# --- SoC-refresh dance (real __get_car_soc) --------------------------------
+@pytest.mark.asyncio
+async def test_get_car_soc_dance_connected_not_charging(driver):
+    """Connected but idle -> the 1 W start/read/stop dance runs and force-emits."""
+    e, rec = driver
+    # Run the real SoC method; keep the heavy action/poll timers stubbed.
+    del e._ModbusEVSEclient__get_car_soc
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_PAUSED  # connected, not charging
+    e.ENTITY_CAR_SOC["current_value"] = None
+    e.client.store[REG_SOC] = 55  # in the strict [2, 97] window -> accepted at once
+
+    result = await _get_soc(e, do_not_use_cache=True)
+
+    assert result == 55
+    assert e.ENTITY_CAR_SOC["current_value"] == 55
+    assert rec.find("soc_change")[-1] == {"new_soc": 55, "old_soc": None}
+    assert rec.find("remaining_range_change")
+    assert e.try_get_new_soc_in_process is False
+    # The dance starts a 1 W charge then stops it again.
+    calls = e._ModbusEVSEclient__set_charger_action.await_args_list
+    assert calls[0].args[0] == "start"
+    assert calls[-1].args[0] == "stop"
+    assert _comm_states(rec)[-1] is True
+    # Polling is paused for the duration of the dance and restored afterwards.
+    assert {"stop": True} in rec.find("evse_polled")
+    e._ModbusEVSEclient__set_poll_strategy.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_car_soc_direct_read_when_already_charging(driver):
+    """Already (dis)charging -> a plain force-read, NO action/poll churn."""
+    e, rec = driver
+    del e._ModbusEVSEclient__get_car_soc
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_CAR_SOC["current_value"] = None
+    e.client.store[REG_SOC] = 55
+
+    result = await _get_soc(e, do_not_use_cache=True)
+
+    assert result == 55
+    assert e.ENTITY_CAR_SOC["current_value"] == 55
+    assert rec.find("soc_change")[-1]["new_soc"] == 55
+    e._ModbusEVSEclient__set_charger_action.assert_not_awaited()
+    e._ModbusEVSEclient__set_poll_strategy.assert_not_awaited()
+    assert e.try_get_new_soc_in_process is False
+
+
+@pytest.mark.asyncio
+async def test_get_car_soc_force_emit_vs_cache_return(driver):
+    """force_emit == do_not_use_cache: cached read is silent, forced re-emits."""
+    e, rec = driver
+    del e._ModbusEVSEclient__get_car_soc
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_CAR_SOC["current_value"] = 55
+    e.client.store[REG_SOC] = 55
+
+    # Cache hit: no modbus read, no event.
+    r1 = await _get_soc(e, do_not_use_cache=False)
+    assert r1 == 55
+    assert rec.find("soc_change") == []
+
+    # Forced refresh re-emits even though the value is unchanged.
+    r2 = await _get_soc(e, do_not_use_cache=True)
+    assert r2 == 55
+    assert rec.find("soc_change")[-1] == {"new_soc": 55, "old_soc": 55}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disconnected_state", [STATE_DISCONNECTED, STATE_LOCKED])
+async def test_get_car_soc_not_connected_returns_unavailable(
+    driver, disconnected_state
+):
+    """No car -> SoC/kwh/range all short-circuit to 'unavailable', no event."""
+    e, rec = driver
+    del e._ModbusEVSEclient__get_car_soc
+    del e.get_car_remaining_range  # run the real range wrapper too
+    e.ENTITY_CHARGER_STATE["current_value"] = disconnected_state
+
+    assert await _get_soc(e, do_not_use_cache=True) == "unavailable"
+    assert await _get_soc(e, do_not_use_cache=False) == "unavailable"
+    assert rec.find("soc_change") == []
+    assert await e.get_car_soc_kwh() == "unavailable"
+    assert await e.get_car_remaining_range() == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_car_soc_none_coerced_to_unavailable(driver):
+    """None from the (here-stubbed) forced read is coerced/cached as 'unavailable'.
+
+    The forced-read loop is stubbed to isolate the None -> 'unavailable' coercion
+    (driver 826-827) and the resulting cache + soc_change emit; the loop's own
+    timeout->None outcome is pinned by test_force_get_register_timeout_*.
+    """
+    e, rec = driver
+    del e._ModbusEVSEclient__get_car_soc
+    e._ModbusEVSEclient__force_get_register = AsyncMock(return_value=None)
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_CAR_SOC["current_value"] = 55
+
+    assert await _get_soc(e, do_not_use_cache=True) == "unavailable"
+    assert e.ENTITY_CAR_SOC["current_value"] == "unavailable"
+    assert rec.find("soc_change")[-1] == {"new_soc": "unavailable", "old_soc": 55}
+    assert rec.find("remaining_range_change")
+
+
+# --- __force_get_register (real forced-read loop) --------------------------
+@pytest.mark.asyncio
+async def test_force_get_register_accepts_first_valid_read(driver):
+    """A value in the strict window is accepted on the first iteration."""
+    e, rec = driver
+    e.client.store[REG_SOC] = 55
+    result = await _force_get(e, REG_SOC, 2, 97, 1, 100)
+    assert result == 55
+    assert _comm_states(rec)[-1] is True
+
+
+@pytest.mark.asyncio
+async def test_force_get_register_relaxed_accept_at_timeout(driver):
+    """At timeout a value inside the relaxed window is still accepted."""
+    e, rec = driver
+    e.MAX_CHARGER_ERROR_STATE_DURATION_IN_SECONDS = 0  # force the timeout branch
+    e.client.store[REG_SOC] = 100  # outside [2,97], inside relaxed [1,100]
+
+    result = await _force_get(e, REG_SOC, 2, 97, 1, 100)
+
+    assert result == 100
+    assert _comm_states(rec)[-1] is True
+    assert e._am_i_active is True  # no escalation
+
+
+@pytest.mark.asyncio
+async def test_force_get_register_timeout_returns_none_and_escalates(driver):
+    """No acceptable value at timeout -> None + full un-recoverable escalation."""
+    e, rec = driver
+    e.v2g_main_app = AsyncMock()
+    e.MAX_CHARGER_ERROR_STATE_DURATION_IN_SECONDS = 0
+    e.client.store[REG_SOC] = 0  # outside strict AND relaxed windows
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING  # was connected
+
+    result = await _force_get(e, REG_SOC, 2, 97, 1, 100)
+
+    assert result is None
+    assert e._am_i_active is False
+    e.v2g_main_app.handle_none_responsive_charger.assert_awaited_once_with(
+        was_car_connected=True
+    )
+    assert _comm_states(rec)[-1] is False
+    assert rec.find("evse_polled")[-1]["stop"] is True
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] == "unavailable"
+    assert e.ENTITY_CAR_SOC["current_value"] == "unavailable"
+    assert rec.find("charge_power_change")[-1] == {"new_power": 0}
+    assert rec.find("soc_change")[-1]["new_soc"] == "unavailable"
+
+
+# --- comms-loss / recovery / bad-config ------------------------------------
+@pytest.mark.asyncio
+async def test_first_modbus_exception_arms_grace_timer(driver):
+    """First failure after init is recoverable: it only arms the grace timer."""
+    e, rec = driver
+    e.v2g_main_app = AsyncMock()
+    e.client.fault = "raise"
+
+    assert await _modbus_read(e, REG_STATE, 1) is None
+    assert e.modbus_exception_counter == 1
+    # A one-shot timer to __handle_un_recoverable_error was armed with delay 60.
+    e.hass.run_in.assert_awaited_once()
+    assert e.hass.run_in.await_args.args[0] == (
+        e._ModbusEVSEclient__handle_un_recoverable_error
+    )
+    assert e.hass.run_in.await_args.kwargs["delay"] == 60
+    # Still recoverable: no comms-fault, no user notification yet.
+    assert _comm_states(rec) == []
+    e.notifier.post_sticky_memo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modbus_exception_recovers_before_timer(driver):
+    """A successful read after one failure resets the fault (Boundary R)."""
+    e, rec = driver
+    e.v2g_main_app = AsyncMock()
+
+    e.client.fault = "raise"
+    assert await _modbus_read(e, REG_STATE, 1) is None
+    assert e.modbus_exception_counter == 1
+
+    e.client.fault = None
+    e.client.store[REG_STATE] = STATE_CHARGING
+    res = await _modbus_read(e, REG_STATE, 1)
+
+    assert res == [STATE_CHARGING]
+    e.v2g_main_app.reset_charger_communication_fault.assert_awaited_once()
+    assert e.modbus_exception_counter == 0
+    assert e.timer_id_check_modus_exception_state is None
+    assert _comm_states(rec)[-1] is True
+
+
+@pytest.mark.asyncio
+async def test_grace_timer_firing_escalates_to_unrecoverable(driver):
+    """When the armed grace timer fires, it escalates to un-recoverable."""
+    e, rec = driver
+    e.v2g_main_app = AsyncMock()
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+
+    e.client.fault = "raise"
+    await _modbus_read(e, REG_STATE, 1)  # arm the timer
+    escalation_cb = e.hass.run_in.await_args.args[0]
+    assert escalation_cb == e._ModbusEVSEclient__handle_un_recoverable_error
+
+    await escalation_cb()  # simulate the timer firing
+
+    assert rec.find("evse_polled")[-1]["stop"] is True
+    assert e._am_i_active is False
+    e.v2g_main_app.handle_none_responsive_charger.assert_awaited_once_with(
+        was_car_connected=True
+    )
+    assert _comm_states(rec)[-1] is False
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] == "unavailable"
+    assert e.ENTITY_CAR_SOC["current_value"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_bad_modbus_config_posts_sticky_memo(driver):
+    """A failure before the first success (counter None) is a config problem."""
+    e, rec = driver
+    e.modbus_exception_counter = None  # never successfully connected yet
+    e.client.fault = "raise"
+
+    assert await _modbus_read(e, REG_STATE, 1) is None
+
+    e.notifier.post_sticky_memo.assert_called_once()
+    assert (
+        e.notifier.post_sticky_memo.call_args.kwargs["memo_id"] == "no_comm_with_evse"
+    )
+    assert rec.find("evse_polled")[-1]["stop"] is True
+    assert _comm_states(rec) == []  # no comms-state emit on the config path
+
+
+# --- poll strategy (real __set_poll_strategy) ------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disconnected_state", [STATE_DISCONNECTED, STATE_LOCKED])
+async def test_set_poll_strategy_minimal_when_disconnected(driver, disconnected_state):
+    """Disconnected -> minimal polling (15 s), and a cancel-first teardown."""
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = disconnected_state
+
+    await _set_poll_strategy(e)
+
+    e.hass.run_every.assert_awaited_once()
+    assert e.hass.run_every.await_args.args[0] == e._ModbusEVSEclient__minimal_polling
+    assert e.hass.run_every.await_args.args[2] == 15
+    assert e.poll_timer_handle is e.hass.run_every.return_value
+    polled = rec.find("evse_polled")
+    assert polled == [{"stop": True}]  # cancel-first only; run_every does not fire
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "connected_state", [STATE_CHARGING, STATE_PAUSED, STATE_DISCHARGING]
+)
+async def test_set_poll_strategy_base_when_connected(driver, connected_state):
+    """Any connected state -> base polling (5 s)."""
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = connected_state
+
+    await _set_poll_strategy(e)
+
+    assert e.hass.run_every.await_args.args[0] == e._ModbusEVSEclient__base_polling
+    assert e.hass.run_every.await_args.args[2] == 5
+    assert e.poll_timer_handle is e.hass.run_every.return_value
+    assert rec.find("evse_polled")[-1]["stop"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_poll_strategy_unavailable_state_coerced_to_minimal(driver):
+    """An 'unavailable' charger state is treated as disconnected -> minimal."""
+    e, _ = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = "unavailable"
+
+    await _set_poll_strategy(e)
+
+    assert e.hass.run_every.await_args.args[0] == e._ModbusEVSEclient__minimal_polling
+    assert e.hass.run_every.await_args.args[2] == 15
+
+
+@pytest.mark.asyncio
+async def test_set_poll_strategy_suppressed_during_soc_dance(driver):
+    """While a forced-SoC read is running, poll strategy is a no-op."""
+    e, rec = driver
+    e.try_get_new_soc_in_process = True
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+
+    await _set_poll_strategy(e)
+
+    e.hass.run_every.assert_not_awaited()
+    assert rec.find("evse_polled") == []
+
+
+@pytest.mark.asyncio
+async def test_minimal_polling_emits_stop_false_and_skips_soc_and_power(driver):
+    """Minimal poll reads only state+lock; a disconnected car still ticks stop=False."""
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_DISCONNECTED  # no state change
+    e.client.store.update({REG_STATE: STATE_DISCONNECTED, REG_LOCKED: 0})
+
+    await _minimal_poll(e)
+
+    assert (
+        rec.find("evse_polled")[-1]["stop"] is False
+    )  # teardown flag, not "disconnected"
+    assert e.ENTITY_CAR_SOC["current_value"] is None  # 538 never read
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] is None  # 526 never read
+    assert e.ENTITY_CHARGER_LOCKED["current_value"] == 0  # 256 read, cached, no event
+
+
+# --- power deviation (>500 W flag, no event/action) ------------------------
+@pytest.mark.asyncio
+async def test_power_deviation_flag_thresholds(driver):
+    """Deviation is a strict >500 W flag; it fires no event and no charger action."""
+    e, rec = driver
+
+    e.requested_charge_power = 3000
+    e._is_power_deviating = False
+    await _handle_power(e, 3600)  # delta 600
+    assert e._is_power_deviating is True
+    assert rec.find("charge_power_change")[-1] == {"new_power": 3600}
+
+    e._is_power_deviating = False
+    e.requested_charge_power = 3000
+    await _handle_power(e, 3500)  # delta exactly 500 -> not deviating (strict >)
+    assert e._is_power_deviating is False
+
+    e._is_power_deviating = False
+    e.requested_charge_power = 3000
+    await _handle_power(e, 2450)  # delta 550
+    assert e._is_power_deviating is True
+
+    # The deviation handler emits ONLY charge_power_change: no charger action and
+    # no side-effect event (no charger_state_change / is_car_connected / evse_polled).
+    assert {n for n, _ in rec.events} == {"charge_power_change"}
+
+
+@pytest.mark.asyncio
+async def test_power_deviation_edge_transitions_and_non_numeric(driver):
+    """Rising/falling edges flip the flag; a non-numeric power is coerced to 0."""
+    e, rec = driver
+
+    e._is_power_deviating = True
+    e.requested_charge_power = 3000
+    await _handle_power(e, 3100)  # delta 100 -> resolves
+    assert e._is_power_deviating is False
+    assert rec.find("charge_power_change")[-1]["new_power"] == 3100
+
+    await _handle_power(e, 4000)  # delta 1000 -> deviates again
+    assert e._is_power_deviating is True
+    assert rec.find("charge_power_change")[-1]["new_power"] == 4000
+
+    e._is_power_deviating = False
+    e.requested_charge_power = 0
+    await _handle_power(e, "unavailable")  # coerced to 0 BEFORE emit
+    assert rec.find("charge_power_change")[-1] == {"new_power": 0}
+    assert e._is_power_deviating is False
+
+
+@pytest.mark.asyncio
+async def test_base_poll_power_deviation_integration(driver):
+    """Deviation surfaces through a full base poll and clears when power realigns."""
+    e, rec = driver
+    e.requested_charge_power = 0
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.client.store.update(
+        {
+            REG_ACTUAL_POWER: int16_to_uint16(4000),
+            REG_STATE: STATE_CHARGING,
+            REG_SOC: 55,
+        }
+    )
+
+    await _base_poll(e)
+
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] == 4000
+    assert rec.find("charge_power_change")[-1] == {"new_power": 4000}
+    assert e._is_power_deviating is True  # 4000 vs requested 0
+    assert rec.find("evse_polled")[-1]["stop"] is False
+
+    # Realign the request; a new actual within 500 W clears the flag.
+    e.requested_charge_power = 4000
+    e.client.store[REG_ACTUAL_POWER] = int16_to_uint16(4200)
+    await _base_poll(e)
+
+    assert rec.find("charge_power_change")[-1] == {"new_power": 4200}
+    assert e._is_power_deviating is False
+
+
+# --- charger-error-state escalation (real __handle_charger_error_state_change)
+# One of the four documented "none-responsive" triggers; fully patched in the
+# base fixture, so unpin it here (register-decode-adjacent -> matters for the
+# MBR/MCE rewrite).
+@pytest.mark.asyncio
+async def test_charger_error_state_arms_final_check_timer(driver):
+    """A non-zero error register arms a one-shot final-check, still recoverable."""
+    e, _ = driver
+    del e._ModbusEVSEclient__handle_charger_error_state_change
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_ERROR_1["current_value"] = 1234  # charger reports an error
+
+    await _handle_error_state(e, new_charger_state=None, is_final_check=False)
+
+    e.hass.run_in.assert_awaited_once()
+    assert e.hass.run_in.await_args.args[0] == (
+        e._ModbusEVSEclient__handle_charger_error_state_change
+    )
+    assert e.hass.run_in.await_args.kwargs["delay"] == 60
+    assert e.hass.run_in.await_args.kwargs["is_final_check"] is True
+    assert e.timer_id_check_error_state is e.hass.run_in.return_value
+    assert e._am_i_active is True  # not yet escalated
+
+
+@pytest.mark.asyncio
+async def test_charger_error_final_check_escalates_to_unrecoverable(driver):
+    """The final check on a persistent error escalates to un-recoverable."""
+    e, rec = driver
+    del e._ModbusEVSEclient__handle_charger_error_state_change
+    e.v2g_main_app = AsyncMock()
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.ENTITY_ERROR_1["current_value"] = 1234
+
+    await _handle_error_state(e, new_charger_state=None, is_final_check=True)
+
+    assert rec.find("evse_polled")[-1]["stop"] is True
+    assert e._am_i_active is False
+    e.v2g_main_app.handle_none_responsive_charger.assert_awaited_once_with(
+        was_car_connected=True
+    )
+    assert _comm_states(rec)[-1] is False
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] == "unavailable"
+    assert e.ENTITY_CAR_SOC["current_value"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_charger_error_cleared_cancels_timer(driver):
+    """When no error is present any more, the pending final-check timer is cleared."""
+    e, _ = driver
+    del e._ModbusEVSEclient__handle_charger_error_state_change
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING  # not an error state
+    for err in (e.ENTITY_ERROR_1, e.ENTITY_ERROR_2, e.ENTITY_ERROR_3, e.ENTITY_ERROR_4):
+        err["current_value"] = 0
+    e.timer_id_check_error_state = MagicMock()  # a timer is pending
+
+    await _handle_error_state(e, new_charger_state=None, is_final_check=False)
+
+    assert e.timer_id_check_error_state is None
+
+
+# --- partial / short modbus result -----------------------------------------
+@pytest.mark.asyncio
+async def test_partial_modbus_result_arms_grace_timer_and_aborts(driver):
+    """A short read aborts processing and arms the grace timer (cannot escalate
+    on its own, because __modbus_read resets the counter before this check)."""
+    e, rec = driver
+    e.v2g_main_app = AsyncMock()
+    e.client.fault = "short"
+    e.client.store.update(
+        {REG_ACTUAL_POWER: 3000, REG_STATE: STATE_CHARGING, REG_SOC: 55}
+    )
+
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+
+    assert e.modbus_exception_counter == 1  # grace timer armed
+    e.hass.run_in.assert_awaited_once()
+    assert e.hass.run_in.await_args.args[0] == (
+        e._ModbusEVSEclient__handle_un_recoverable_error
+    )
+    # Processing aborted: no entity was updated from the partial batch.
+    assert e.ENTITY_CHARGER_CURRENT_POWER["current_value"] is None
+    assert rec.find("charge_power_change") == []
+
+
+# --- write-side + repeated-exception branches ------------------------------
+@pytest.mark.asyncio
+async def test_write_exception_arms_grace_timer(driver):
+    """A failed write follows the same recoverable-first path as a failed read."""
+    e, _ = driver
+    e.v2g_main_app = AsyncMock()
+    e.client.fault = "raise"
+
+    assert await _modbus_write(e, e.SET_ACTION_REGISTER, 2) is None
+    assert e.modbus_exception_counter == 1
+    e.hass.run_in.assert_awaited_once()
+    assert e.hass.run_in.await_args.args[0] == (
+        e._ModbusEVSEclient__handle_un_recoverable_error
+    )
+    assert e.hass.run_in.await_args.kwargs["delay"] == 60
+
+
+@pytest.mark.asyncio
+async def test_repeated_exception_without_timer_returns_none(driver):
+    """A repeat failure after the grace timer expired is treated as unrecoverable."""
+    e, _ = driver
+    e.v2g_main_app = AsyncMock()
+    e.modbus_exception_counter = 1  # already had a failure
+    e.timer_id_check_modus_exception_state = None  # grace period elapsed
+    e.client.fault = "raise"
+
+    assert await _modbus_read(e, REG_STATE, 1) is None
+    # __handle_modbus_exception returned unrecoverable -> read bailed with None.
+    assert e.modbus_exception_counter == 1
+
+
+@pytest.mark.asyncio
+async def test_force_get_register_returns_none_on_unrecoverable_exception(driver):
+    """An in-loop ModbusException that is already unrecoverable bails with None."""
+    e, _ = driver
+    e.v2g_main_app = AsyncMock()
+    e.modbus_exception_counter = 1
+    e.timer_id_check_modus_exception_state = None  # grace period elapsed
+    e.client.fault = "raise"
+
+    result = await _force_get(e, REG_SOC, 2, 97, 1, 100)
+
+    assert result is None
+    # The bare early-return does not itself escalate; the expired timer already did.
+    assert e._am_i_active is True
+
+
+# --- charger_state_change secondary branches -------------------------------
+@pytest.mark.asyncio
+async def test_state_change_into_error_invokes_error_handler(driver):
+    """A transition INTO a charger error state routes to the error handler."""
+    e, rec = driver
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING
+    e.client.store.update({REG_STATE: STATE_ERROR, REG_ACTUAL_POWER: 0, REG_SOC: 55})
+
+    await _process(e, e.CHARGER_POLLING_ENTITIES)
+
+    e._ModbusEVSEclient__handle_charger_error_state_change.assert_awaited()
+    assert rec.find("charger_state_change")[-1]["new_charger_state"] == STATE_ERROR
+
+
+@pytest.mark.asyncio
+async def test_state_change_suppressed_during_soc_dance(driver):
+    """A (non-error) state change emits nothing while a forced-SoC read runs."""
+    e, rec = driver
+    e.try_get_new_soc_in_process = True
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_PAUSED
+
+    await _update(e, e.ENTITY_CHARGER_STATE, STATE_CHARGING)
+
+    assert rec.find("charger_state_change") == []
+    assert rec.find("is_car_connected") == []


### PR DESCRIPTION
## What

Expands the charger-driver regression net
(`test_modbus_evse_client_scenarios.py`) from 9 to 42 tests so the upcoming
359 charger refactor can be verified to preserve behaviour. Test-only — no
production code changes.

## Why

359 restructures the `modbus_evse_client` monolith into a `chargers/` package
(MBR/MCE dataclasses, EV split). Before that driver is touched, this PR pins
the current observable behaviour of the reliability-critical lifecycle paths
the base net previously patched away, so the refactor can be proven
behaviour-neutral. This is "Fase 0" (the safety net) of the staged 359 → dev
migration.

## What is now pinned

Every new test drives the real driver and asserts on the observable boundary
(event_bus events + cached entity values + the direct `v2g_main_app` /
`notifier` calls the driver makes instead of an event):

- SoC-refresh dance (real `__get_car_soc`): both branches, `force_emit`, and
  the 0/None → `unavailable` coercion
- Forced-read loop (`__force_get_register`): strict/relaxed accept,
  timeout → None + un-recoverable escalation
- Communication loss/recovery: grace-timer arming, recovery (comms-fault
  reset), un-recoverable, bad-config sticky memo, and the write-exception and
  repeat-exception branches
- Charger-error-state escalation (real `__handle_charger_error_state_change`):
  final-check timer, escalation, cancel-on-clear
- Partial/short modbus result: arm + abort
- Poll-strategy base (5 s) / minimal (15 s) selection + `evse_polled` stop
  semantics (`stop=True` = polling torn down, not "disconnected")
- Power-deviation >500 W flag (no event, no charger action)

A fault mode (`raise` / `short`) is added to the fake Modbus client to drive
the communication-loss paths.

## Verification

- Full suite green: **995 passed** (was 962).
- The new tests were adversarially reviewed for false-greens / wrong-pins /
  not-real-path defects; none survived. Three assertions were hardened and two
  coverage gaps (charger-error escalation, partial-read) were closed as a
  result.

## Notes

- Test-only; no changelog entry (non-functional, like tooling changes).
- A companion per-event contract checklist documents each event's kwargs, emit
  condition, keep/migrate decision, and exact consumers — the draaiboek for the
  Fase 2 charger port.
