### PR TITLE
Introduce an ElectricVehicle abstraction and read car SoC from it

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/evs/__init__.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/evs/__init__.py
@@ -1,0 +1,1 @@
+"""Electric-vehicle abstraction package."""

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/evs/electric_vehicle.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/evs/electric_vehicle.py
@@ -1,0 +1,75 @@
+"""Electric vehicle (EV) abstraction.
+
+Holds the connected car's state of charge and exposes its energy content and
+range, so consumers can read the car from one place instead of from the charger.
+
+Fase 1 of the 359 migration (EV-abstraction before the charger refactor): the
+charger monolith stays the SOLE emitter and owner of the SoC getters. This
+object subscribes to the ``soc_change`` event and mirrors the value with a
+SYNC, NON-emitting setter, and derives soc_kwh / remaining-range from the SAME
+live car constants the charger reads (``c.CAR_MAX_CAPACITY_IN_KWH`` /
+``c.CAR_CONSUMPTION_WH_PER_KM``). Reading the live constants — rather than a
+stored copy — keeps the derived values bit-identical to the charger in EVERY
+state, including the boot window before the car settings are loaded (both then
+read the module default). Fase 2 (the charger port) makes this the
+authoritative, emitting SoC owner and moves the car constants into it.
+"""
+
+from appdaemon.plugins.hass.hassapi import Hass
+
+from .. import constants as c
+from ..event_bus import EventBus
+from ..log_wrapper import get_class_method_logger
+
+# SoC sentinels. Dev represents "no valid SoC" with the string "unavailable"
+# (never None), so the derived getters must return the same string and consumers'
+# EMPTY_STATES guards keep firing identically.
+_EMPTY_SOC_VALUES = [None, "unavailable", "unknown"]
+
+
+class ElectricVehicle:
+    """The single connected electric vehicle."""
+
+    def __init__(self, hass: Hass, event_bus: EventBus):
+        self.hass = hass
+        self._eb = event_bus
+        self.__log = get_class_method_logger(module_name="electric_vehicle")
+        self._soc = None
+
+        # Subscribe here in __init__ (before any module's initialize() runs) and
+        # with a SYNC handler: pyee runs sync listeners inline during emit, so
+        # ev.soc is refreshed before the async soc_change consumers (e.g. main_app)
+        # execute in the same dispatch. No registration-order fragility.
+        self._eb.add_event_listener("soc_change", self.update_soc)
+        self.__log("initialised.")
+
+    def update_soc(self, new_soc, old_soc=None):
+        """Mirror the charger's SoC. NON-emitting in Fase 1 (the charger is the
+        sole emitter). ``old_soc`` is accepted (a soc_change kwarg) but unused."""
+        self._soc = new_soc
+
+    @property
+    def soc(self):
+        """State of charge in %, or the string "unavailable"."""
+        return self._soc
+
+    @property
+    def soc_kwh(self):
+        """State of charge in kWh, or "unavailable".
+
+        Mirrors ``modbus_evse_client.get_car_soc_kwh`` (same live constant).
+        """
+        if self._soc in _EMPTY_SOC_VALUES:
+            return "unavailable"
+        return round(self._soc * float(c.CAR_MAX_CAPACITY_IN_KWH / 100), 2)
+
+    @property
+    def remaining_range_km(self):
+        """Remaining range in km, or "unavailable".
+
+        Mirrors ``modbus_evse_client.get_car_remaining_range`` (same live constant).
+        """
+        soc_kwh = self.soc_kwh
+        if soc_kwh in _EMPTY_SOC_VALUES:
+            return "unavailable"
+        return int(round(soc_kwh * 1000 / c.CAR_CONSUMPTION_WH_PER_KM, 0))

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -99,6 +99,7 @@ class V2Gliberty:
     no_schedule_notification_is_planned: bool
 
     evse_client_app: object = None
+    electric_vehicle: object = None
     fm_client_app: object = None
     reservations_client: object = None
     notifier: Notifier = None
@@ -257,11 +258,11 @@ class V2Gliberty:
 
         # Needed in many of the cases further in this method
         now = get_local_now()
-        soc = await self.evse_client_app.get_car_soc()
+        soc = self.electric_vehicle.soc
 
         if charge_mode == "Automatic":
             # update_charge_mode takes charger control already, not needed here.
-            soc_kwh = await self.evse_client_app.get_car_soc_kwh()
+            soc_kwh = self.electric_vehicle.soc_kwh
             if soc_kwh in self.EMPTY_STATES:
                 self.__log("SoC_kWh is 'unknown', abort.")
                 return
@@ -372,7 +373,7 @@ class V2Gliberty:
 
             if not self.in_boost_to_reach_min_soc:
                 # Not checking > max charge (97%), we could also want to discharge based on schedule
-                soc_kwh = await self.evse_client_app.get_car_soc_kwh()
+                soc_kwh = self.electric_vehicle.soc_kwh
                 schedule = None
                 try:
                     schedule = await self.fm_client_app.get_new_schedule(
@@ -1007,7 +1008,7 @@ class V2Gliberty:
         ):
             message = (
                 f"Car battery at {new_soc} %, "
-                f"range ≈ {await self.evse_client_app.get_car_remaining_range()} km."
+                f"range ≈ {self.electric_vehicle.remaining_range_km} km."
             )
             self.__log(f"{message=}")
             await self.notifier.notify_user(
@@ -1201,7 +1202,7 @@ class V2Gliberty:
             self.__log("aborted: car is not connected")
             return
 
-        if await self.evse_client_app.get_car_soc() in self.EMPTY_STATES:
+        if self.electric_vehicle.soc in self.EMPTY_STATES:
             self.__log("aborted: soc is 'unknown'")
             return
 
@@ -1290,7 +1291,7 @@ class V2Gliberty:
 
         exp_soc_values = list(
             accumulate(
-                [await self.evse_client_app.get_car_soc()]
+                [self.electric_vehicle.soc]
                 + convert_mw_to_percentage_points(
                     values,
                     resolution,

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
@@ -8,6 +8,7 @@ from .ha_ui_manager import HAUIManager
 from .notifier_util import Notifier
 from .v2g_globals import V2GLibertyGlobals
 from .modbus_evse_client import ModbusEVSEclient
+from .evs.electric_vehicle import ElectricVehicle
 from .fm_client import FMClient
 from .reservations_client import ReservationsClient
 from .main_app import V2Gliberty
@@ -61,6 +62,12 @@ class V2GLibertyApp(Hass):
         start_module = datetime.now()
         reservations_client = ReservationsClient(self, event_bus=event_bus)
         self._log_init_time("ReservationsClient", start_module)
+
+        # Construct the EV before main_app so its soc_change subscription is
+        # registered first (belt-and-braces alongside its sync, run-inline handler).
+        start_module = datetime.now()
+        electric_vehicle = ElectricVehicle(self, event_bus=event_bus)
+        self._log_init_time("ElectricVehicle", start_module)
 
         start_module = datetime.now()
         main_app = V2Gliberty(self, event_bus=event_bus, notifier=notifier)
@@ -124,6 +131,7 @@ class V2GLibertyApp(Hass):
         modbus_evse_client.v2g_main_app = main_app
         modbus_evse_client.v2g_globals = v2g_globals
         main_app.evse_client_app = modbus_evse_client
+        main_app.electric_vehicle = electric_vehicle
         main_app.fm_client_app = fm_client
         main_app.reservations_client = reservations_client
         data_repairer.data_store = data_store

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_electric_vehicle.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_electric_vehicle.py
@@ -1,0 +1,92 @@
+"""Characterisation tests for the ElectricVehicle abstraction (Fase 1).
+
+Pin the EV's SoC mirror and its derived soc_kwh / remaining_range so they stay
+bit-identical to the charger getters (modbus_evse_client.get_car_soc_kwh /
+get_car_remaining_range) after main_app is repointed onto the EV. In Fase 1 the
+EV is a NON-emitting mirror: it subscribes to soc_change and must never re-emit,
+and it derives from the same live car constants the charger reads.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import apps.v2g_liberty.constants as c
+from apps.v2g_liberty.event_bus import EventBus
+from apps.v2g_liberty.evs.electric_vehicle import ElectricVehicle
+from apps.v2g_liberty.modbus_evse_client import ModbusEVSEclient
+from apps.dev_tools.charger_scenarios import STATE_CHARGING
+
+
+def _make_ev():
+    hass = MagicMock()
+    bus = EventBus(hass)
+    return ElectricVehicle(hass, event_bus=bus), bus
+
+
+def test_derivations_for_known_soc():
+    ev, _ = _make_ev()
+    ev.update_soc(55)
+    assert ev.soc == 55
+    # Same formula + live constant as modbus_evse_client.get_car_soc_kwh / range.
+    assert ev.soc_kwh == round(55 * float(c.CAR_MAX_CAPACITY_IN_KWH / 100), 2)
+    assert ev.remaining_range_km == int(
+        round(ev.soc_kwh * 1000 / c.CAR_CONSUMPTION_WH_PER_KM, 0)
+    )
+
+
+@pytest.mark.parametrize("empty", ["unavailable", "unknown", None])
+def test_empty_soc_sentinels_are_safe(empty):
+    """A non-numeric SoC yields "unavailable" from every derived getter (no crash)."""
+    ev, _ = _make_ev()
+    ev.update_soc(empty)
+    assert ev.soc == empty
+    assert ev.soc_kwh == "unavailable"
+    assert ev.remaining_range_km == "unavailable"
+
+
+def test_update_soc_does_not_emit():
+    ev, bus = _make_ev()
+    seen = []
+    bus.add_event_listener("soc_change", lambda **kw: seen.append("soc_change"))
+    bus.add_event_listener("remaining_range_change", lambda **kw: seen.append("range"))
+    ev.update_soc(55)
+    # The EV mirror must not re-emit either event in Fase 1.
+    assert seen == []
+
+
+def test_ev_updates_synchronously_on_emit():
+    """The EV subscribes to soc_change and refreshes ev.soc inline during emit."""
+    ev, bus = _make_ev()
+    bus.emit_event("soc_change", new_soc=55, old_soc=50)
+    assert ev.soc == 55
+
+
+@pytest.mark.asyncio
+async def test_ev_derivations_match_charger_getters():
+    """Differential parity: the EV and the REAL charger getters agree bit-for-bit.
+
+    This is the "behaviour unchanged" anchor for Fase 1 — it drives one SoC
+    through both runtimes so a drift on either side (formula or constant) fails.
+    """
+    hass = MagicMock()
+    for m in ("set_state", "run_every", "run_in", "get_state", "cancel_timer"):
+        setattr(hass, m, AsyncMock())
+    bus = EventBus(hass)
+
+    charger = ModbusEVSEclient(hass, bus, MagicMock())
+    charger.client = MagicMock()  # is_car_connected only needs a non-None client
+    charger._am_i_active = True
+    charger.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING  # connected
+    charger.ENTITY_CAR_SOC["current_value"] = 55
+
+    ev = ElectricVehicle(hass, event_bus=bus)
+    ev.update_soc(55)
+    try:
+        assert ev.soc == await charger.get_car_soc()
+        assert ev.soc_kwh == await charger.get_car_soc_kwh()
+        assert ev.remaining_range_km == await charger.get_car_remaining_range()
+    finally:
+        # Reset the shared class-level entity caches for test isolation.
+        charger.ENTITY_CHARGER_STATE["current_value"] = None
+        charger.ENTITY_CAR_SOC["current_value"] = None

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_max_soc_notification.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_max_soc_notification.py
@@ -32,7 +32,9 @@ def v2g():
 
     instance.evse_client_app = MagicMock()
     instance.evse_client_app.is_charging = AsyncMock(return_value=True)
-    instance.evse_client_app.get_car_remaining_range = AsyncMock(return_value=278)
+    # Range now comes from the EV abstraction (a sync property).
+    instance.electric_vehicle = MagicMock()
+    instance.electric_vehicle.remaining_range_km = 278
 
     return instance
 

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_modbus_evse_client_scenarios.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_modbus_evse_client_scenarios.py
@@ -32,6 +32,7 @@ from apps.dev_tools.charger_scenarios import (
     STATE_PAUSED,
     int16_to_uint16,
 )
+import apps.v2g_liberty.constants as c
 from apps.v2g_liberty.event_bus import EventBus
 from apps.v2g_liberty.modbus_evse_client import ModbusEVSEclient
 
@@ -878,3 +879,25 @@ async def test_state_change_suppressed_during_soc_dance(driver):
 
     assert rec.find("charger_state_change") == []
     assert rec.find("is_car_connected") == []
+
+
+# --- SoC -> kWh -> range derivation (Fase-1 EV-parity anchor) ---------------
+@pytest.mark.asyncio
+async def test_soc_getter_derivations(driver):
+    """Pin the charger's SoC->kWh->range derivation that the EV mirrors bit-for-bit.
+
+    Paired with test_electric_vehicle.py: both sides use round(soc*cap/100, 2)
+    and int(round(kwh*1000/consumption, 0)), so a drift on either side fails.
+    """
+    e, _ = driver
+    del e._ModbusEVSEclient__get_car_soc  # real SoC getter
+    del e.get_car_remaining_range  # real range wrapper
+    e.ENTITY_CHARGER_STATE["current_value"] = STATE_CHARGING  # connected
+    e.ENTITY_CAR_SOC["current_value"] = 55
+
+    assert await e.get_car_soc() == 55
+    soc_kwh = await e.get_car_soc_kwh()
+    assert soc_kwh == round(55 * float(c.CAR_MAX_CAPACITY_IN_KWH / 100), 2)
+    assert await e.get_car_remaining_range() == int(
+        round(soc_kwh * 1000 / c.CAR_CONSUMPTION_WH_PER_KM, 0)
+    )


### PR DESCRIPTION
## Summary

Adds an `evs/` package with an `ElectricVehicle` that owns the connected car's
state of charge, and repoints `main_app`'s SoC / kWh / range reads onto it. The
charger monolith (`modbus_evse_client.py`) is **not touched** and stays the sole
SoC emitter. Behaviour-preserving — this is the EV-first step of the staged `359`
migration, decoupling car-state reads from the charger ahead of the charger port.

### Design

- **The EV subscribes to `soc_change`** with a **sync, non-emitting** handler, so
  the charger remains the sole emitter and *zero lines of the charger hot-path
  change* (the Fase-0 regression net stays green by construction). A sync pyee
  listener runs inline during `emit`, so `ev.soc` is fresh before the async
  `soc_change` consumers run in the same dispatch — no registration-order fragility.
- **Derivations read the same live constants as the charger**
  (`c.CAR_MAX_CAPACITY_IN_KWH` / `c.CAR_CONSUMPTION_WH_PER_KM`), so `soc_kwh` /
  `remaining_range_km` are bit-identical to the charger getters in every state,
  including the boot window before the car settings load.
- Keeps dev's `"unavailable"` string sentinel (not `None`) so `EMPTY_STATES`
  guards keep firing identically.
- **Lean scope:** no `BaseEV` ABC, registry, min/max-SoC, clamping or
  `initialise_ev` — only what dev needs now.

### Changes

- **New:** `evs/__init__.py`, `evs/electric_vehicle.py` (`soc`, `soc_kwh`,
  `remaining_range_km`, non-emitting `update_soc`).
- `v2g_app.py`: construct the EV before `main_app` and wire it in.
- `main_app.py`: repoint 6 reads — `get_car_soc()` → `ev.soc` (×3),
  `get_car_soc_kwh()` → `ev.soc_kwh` (×2), `get_car_remaining_range()` →
  `ev.remaining_range_km` (×1, inside `__handle_soc_change`).
- **Tests:** `test_electric_vehicle.py` (new, incl. a **differential parity test**
  that drives one SoC through both the EV and the real charger getters and asserts
  they agree); a charger-side derivation-parity test added to the Fase-0 net;
  `test_main_app_max_soc_notification.py` fixture repointed to the EV.

### Behaviour-neutrality & testing

- Derivations are bit-identical (same formula + same live constants); the
  differential parity test pins EV == charger at runtime.
- Adversarially reviewed: one boot-window init-timing divergence was found and
  fixed (the EV reads the live constants instead of a value that was `None` until
  init); everything else confirmed benign.
- Full suite: **1003 passed**, ruff clean. No consumer sees a changed value/type.
