### PR TITLE
Auto-switch to Automatic when a paused reconnect prompt goes unanswered

### DIFF
--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/monitor_pause_at_reconnect.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/monitor_pause_at_reconnect.py
@@ -2,10 +2,10 @@
 
 from appdaemon.plugins.hass.hassapi import Hass
 
-from . import constants as c
 from .event_bus import EventBus
 from .notifier_util import Notifier
 from .log_wrapper import get_class_method_logger
+from .timer_utils import cancel_timer_silent, set_oneshot_timer
 
 
 class MonitorPauseAtReconnect:
@@ -14,6 +14,11 @@ class MonitorPauseAtReconnect:
     desired mode or if switching to Automatic is preferred.
     This module also triggers for Charge or Discharge during reconnect, eventhough it is expected
     to occure seldom as these are automatically reset to Automatic at disconnect.
+
+    If the user does not respond to the notification within
+    ``AUTO_SWITCH_TIMEOUT_SECONDS`` the charge mode is switched to Automatic
+    automatically. Without this a forgotten Pause would leave the reconnected
+    car under the charger's own control, which (auto)starts charging on connect.
     """
 
     hass: Hass = None
@@ -22,11 +27,15 @@ class MonitorPauseAtReconnect:
     NOTIFICATION_TAG: str = "switch_to_automatic_or_not"
     ACTION_KEEP_CURRENT: str = "keep_current"
     ACTION_TO_AUTOMATIC: str = "automatic"
+    # If the user does not respond to the reconnect prompt within this period,
+    # the charge mode is switched to Automatic automatically.
+    AUTO_SWITCH_TIMEOUT_SECONDS: int = 10 * 60
 
     def __init__(self, hass: Hass, event_bus: EventBus, notifier: Notifier):
         self.hass = hass
         self.notifier = notifier
         self.event_bus = event_bus
+        self._auto_switch_timer_handle: str = ""
 
         self.__log = get_class_method_logger(module_name="monitor_pause_at_reconnect")
 
@@ -36,8 +45,37 @@ class MonitorPauseAtReconnect:
 
         self.__log("Completed MonitorPauseAtReconnect")
 
+    async def initialize(self):
+        """Register the charge-mode listener.
+
+        A charge-mode change by ANY means (the UI radio buttons, an automation,
+        or the reconnect notification) cancels a pending auto-switch fallback, so
+        the fallback only ever fires when the user genuinely did not respond to
+        the reconnect prompt.
+        """
+        await self.hass.listen_state(
+            self._handle_charge_mode_change,
+            "input_select.charge_mode",
+        )
+        self.__log("Registered charge_mode listener.")
+
+    async def _handle_charge_mode_change(self, entity, attribute, old, new, kwargs):
+        """Cancel a pending auto-switch fallback when the charge mode changes.
+
+        Any deliberate charge-mode change counts as the user having responded,
+        so the fallback must not fire afterwards. A no-op when no timer is armed.
+        """
+        if new == old:
+            return
+        await cancel_timer_silent(self.hass, self._auto_switch_timer_handle)
+        self._auto_switch_timer_handle = ""
+
     async def _handle_chosen_charge_mode(self, user_action: str):
         self.__log(f"user_action: '{user_action}'.")
+
+        # The user responded in time: cancel the pending auto-switch fallback.
+        await cancel_timer_silent(self.hass, self._auto_switch_timer_handle)
+        self._auto_switch_timer_handle = ""
 
         # Clear notification from other users phone
         self.notifier.clear_notification(tag=self.NOTIFICATION_TAG)
@@ -52,9 +90,28 @@ class MonitorPauseAtReconnect:
         else:
             self.__log(f"Unknown user_action: '{user_action}'.", level="WARNING")
 
+    async def _auto_switch_to_automatic(self, kwargs: dict = None):
+        """Fallback when the user does not respond to the reconnect prompt.
+
+        Scheduled as a one-shot timer by :meth:`_handle_connected_state_change`.
+        AppDaemon passes its scheduling kwargs as a single positional dict, which
+        is ignored here.
+        """
+        self._auto_switch_timer_handle = ""
+        self.__log(
+            "No response to reconnect prompt within timeout: "
+            "switching charge_mode to 'Automatic'."
+        )
+        # Clear the prompt and switch to Automatic (main app reacts via HA event).
+        self.notifier.clear_notification(tag=self.NOTIFICATION_TAG)
+        await self.hass.turn_on("input_boolean.chargemodeautomatic")
+
     async def _handle_connected_state_change(self, is_car_connected: bool):
         if not is_car_connected:
-            # Car was disconnected, no need to notify now
+            # Car was disconnected, no need to notify now. Drop any pending
+            # auto-switch fallback from an earlier reconnect.
+            await cancel_timer_silent(self.hass, self._auto_switch_timer_handle)
+            self._auto_switch_timer_handle = ""
             return
 
         charge_mode = await self.hass.get_state("input_select.charge_mode", None)
@@ -81,13 +138,23 @@ class MonitorPauseAtReconnect:
         ]
 
         await self.notifier.notify_user(
-            message=f"Would you like to set it to 'Automatic'?",
+            message="Would you like to set it to 'Automatic'?",
             title=f"Car connected, the app is set to '{charge_mode}'",
             tag=self.NOTIFICATION_TAG,
             send_to_all=True,
-            ttl=30 * 60,
+            ttl=self.AUTO_SWITCH_TIMEOUT_SECONDS,
             actions=user_actions,
             callback=self._handle_chosen_charge_mode,
+        )
+
+        # If the user does not respond within the timeout, switch to Automatic
+        # automatically so a forgotten Pause does not leave the reconnected car
+        # under the charger's own (autostart) control.
+        self._auto_switch_timer_handle = await set_oneshot_timer(
+            self.hass,
+            self._auto_switch_timer_handle,
+            self._auto_switch_to_automatic,
+            delay=self.AUTO_SWITCH_TIMEOUT_SECONDS,
         )
 
         self.__log(

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/v2g_app.py
@@ -169,6 +169,8 @@ class V2GLibertyApp(Hass):
         await notifier.initialize()
         self._log_init_time("notifier.initialize()", start_module)
 
+        await pause_at_reconnect.initialize()
+
         start_module = datetime.now()
         try:
             await data_store.initialise()

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_monitor_pause_at_reconnect.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_monitor_pause_at_reconnect.py
@@ -1,8 +1,7 @@
 import logging
 import pytest
-from unittest.mock import AsyncMock, MagicMock, call, ANY
+from unittest.mock import AsyncMock, MagicMock, ANY
 from apps.v2g_liberty.monitor_pause_at_reconnect import MonitorPauseAtReconnect
-from apps.v2g_liberty import constants as c
 from apps.v2g_liberty.event_bus import EventBus
 from apps.v2g_liberty.notifier_util import Notifier
 
@@ -58,6 +57,18 @@ async def test_handle_connected_state_change_automatic(monitor, mock_hass):
     await monitor._handle_connected_state_change(True)
     mock_hass.get_state.assert_called_once_with("input_select.charge_mode", None)
     monitor.notifier.notify_user.assert_not_called()
+    # No prompt means no auto-switch fallback may be armed.
+    mock_hass.run_in.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_connected_state_change_none(monitor, mock_hass):
+    """Test that nothing happens (and no timer is armed) when charge mode is None."""
+    mock_hass.get_state.return_value = None
+    await monitor._handle_connected_state_change(True)
+    mock_hass.get_state.assert_called_once_with("input_select.charge_mode", None)
+    monitor.notifier.notify_user.assert_not_called()
+    mock_hass.run_in.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -71,7 +82,7 @@ async def test_handle_connected_state_change_pause(monitor, mock_hass, mock_noti
         title="Car connected, the app is set to 'Pause'",
         tag=monitor.NOTIFICATION_TAG,
         send_to_all=True,
-        ttl=30 * 60,
+        ttl=monitor.AUTO_SWITCH_TIMEOUT_SECONDS,
         actions=ANY,
         callback=monitor._handle_chosen_charge_mode,
     )
@@ -88,7 +99,7 @@ async def test_handle_connected_state_change_stop(monitor, mock_hass, mock_notif
         title="Car connected, the app is set to 'Pause'",
         tag=monitor.NOTIFICATION_TAG,
         send_to_all=True,
-        ttl=30 * 60,
+        ttl=monitor.AUTO_SWITCH_TIMEOUT_SECONDS,
         actions=ANY,
         callback=monitor._handle_chosen_charge_mode,
     )
@@ -105,7 +116,7 @@ async def test_handle_connected_state_change_charge(monitor, mock_hass, mock_not
         title="Car connected, the app is set to 'Charge'",
         tag=monitor.NOTIFICATION_TAG,
         send_to_all=True,
-        ttl=30 * 60,
+        ttl=monitor.AUTO_SWITCH_TIMEOUT_SECONDS,
         actions=ANY,
         callback=monitor._handle_chosen_charge_mode,
     )
@@ -143,3 +154,91 @@ async def test_handle_chosen_charge_mode_unknown(
         tag=monitor.NOTIFICATION_TAG
     )
     mock_hass.turn_on.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_schedules_auto_switch_timer(monitor, mock_hass):
+    """A reconnect in Pause schedules the auto-switch-to-Automatic fallback timer."""
+    mock_hass.get_state.return_value = "Pause"
+    await monitor._handle_connected_state_change(True)
+    # A one-shot timer to _auto_switch_to_automatic is armed with the timeout delay.
+    mock_hass.run_in.assert_awaited_once_with(
+        monitor._auto_switch_to_automatic,
+        delay=monitor.AUTO_SWITCH_TIMEOUT_SECONDS,
+    )
+    # The returned handle is remembered so it can be cancelled later.
+    assert monitor._auto_switch_timer_handle == mock_hass.run_in.return_value
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_to_automatic_switches_mode(
+    monitor, mock_hass, mock_notifier
+):
+    """The fallback clears the prompt and switches the charge mode to Automatic."""
+    monitor._auto_switch_timer_handle = "pending_handle"
+    await monitor._auto_switch_to_automatic()
+    mock_notifier.clear_notification.assert_called_once_with(
+        tag=monitor.NOTIFICATION_TAG
+    )
+    mock_hass.turn_on.assert_called_once_with("input_boolean.chargemodeautomatic")
+    # The handle is cleared so a stale value cannot be cancelled twice.
+    assert monitor._auto_switch_timer_handle == ""
+
+
+@pytest.mark.asyncio
+async def test_user_response_cancels_pending_auto_switch(monitor, mock_hass):
+    """Any user response cancels the pending auto-switch fallback timer."""
+    mock_hass.timer_running = AsyncMock(return_value=True)
+    monitor._auto_switch_timer_handle = "pending_handle"
+    await monitor._handle_chosen_charge_mode(monitor.ACTION_KEEP_CURRENT)
+    mock_hass.cancel_timer.assert_awaited_once_with("pending_handle", silent=True)
+    assert monitor._auto_switch_timer_handle == ""
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_pending_auto_switch(
+    monitor, mock_hass, mock_notifier
+):
+    """A disconnect cancels a pending auto-switch fallback and does not notify."""
+    mock_hass.timer_running = AsyncMock(return_value=True)
+    monitor._auto_switch_timer_handle = "pending_handle"
+    await monitor._handle_connected_state_change(False)
+    mock_hass.cancel_timer.assert_awaited_once_with("pending_handle", silent=True)
+    assert monitor._auto_switch_timer_handle == ""
+    mock_hass.get_state.assert_not_called()
+    mock_notifier.notify_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_initialize_registers_charge_mode_listener(monitor, mock_hass):
+    """initialize() subscribes to charge_mode changes so any change can cancel."""
+    await monitor.initialize()
+    mock_hass.listen_state.assert_awaited_once_with(
+        monitor._handle_charge_mode_change,
+        "input_select.charge_mode",
+    )
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_change_cancels_pending_auto_switch(monitor, mock_hass):
+    """A charge_mode change by any means cancels a pending auto-switch fallback."""
+    mock_hass.timer_running = AsyncMock(return_value=True)
+    monitor._auto_switch_timer_handle = "pending_handle"
+    # e.g. the user picks Automatic (then Pause) via the UI radio buttons.
+    await monitor._handle_charge_mode_change(
+        "input_select.charge_mode", "state", "Stop", "Automatic", {}
+    )
+    mock_hass.cancel_timer.assert_awaited_once_with("pending_handle", silent=True)
+    assert monitor._auto_switch_timer_handle == ""
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_unchanged_does_not_cancel(monitor, mock_hass):
+    """A no-op state callback (new == old) leaves a pending fallback intact."""
+    mock_hass.timer_running = AsyncMock(return_value=True)
+    monitor._auto_switch_timer_handle = "pending_handle"
+    await monitor._handle_charge_mode_change(
+        "input_select.charge_mode", "state", "Stop", "Stop", {}
+    )
+    mock_hass.cancel_timer.assert_not_awaited()
+    assert monitor._auto_switch_timer_handle == "pending_handle"


### PR DESCRIPTION
## Problem (old bug)
When charge_mode is Pause (Stop), control is handed to the charger, which
re-enables its own autostart-on-connect. If the car is reconnected while the
app is left on Pause (e.g. forgotten), the charger autostart-charges the car to
full — defeating the "pause" intent. The existing reconnect notification asked
to switch to Automatic, but on ttl expiry it only cleared the message and took
no action, so a non-responding user's car still charged to full.

## Fix
- Lower the reconnect notification ttl from 30 → 10 min.
- If the user does not respond within that time, switch charge_mode to Automatic
  automatically, so the car comes under V2G control instead of the charger's
  autostart.
- Any deliberate response cancels the fallback: the notification buttons, a
  disconnect, or any charge_mode change via the UI radio buttons (new
  `input_select.charge_mode` listener registered in `initialize()`).