### PR TITLE
Guard the max-SoC notification against a non-numeric new SoC

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -7,6 +7,7 @@
 - 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#469)
 - 🪲 BUG: Fix db schema validation (#470)
 - 🪲 BUG: Paused app lets the charger charge the car to full on reconnect (#480, #481)
+- 🪲 BUG: Guard the max-SoC notification against a non-numeric new SoC (#483)
 
 
 ### Added

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -10,6 +10,7 @@ That file also contains possible changes that the next release might include.
 - 🪲 BUG: "Battery at max SoC" notification reports the wrong range after a restart (#469)
 - 🪲 BUG: Fix db schema validation (#470)
 - 🪲 BUG: Paused app lets the charger charge the car to full on reconnect (#480, #481)
+- 🪲 BUG: Guard the max-SoC notification against a non-numeric new SoC (#483)
 
 ### Added
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -997,11 +997,14 @@ class V2Gliberty:
             )
 
         if (
-            # Only on a genuine rise to max SoC, not on the first reading after a
-            # restart (old_soc is then None/"unavailable"). This also avoids
+            # Only on a genuine rise to max SoC. Both readings must be numeric:
+            # old_soc is None/"unavailable" on the first reading after a restart,
+            # and new_soc is "unavailable" right after the car is disconnected —
+            # comparing either against a number would raise. Guarding also avoids
             # computing the range before the car settings are loaded, which would
             # use the default battery capacity and report a wrong range.
             isinstance(old_soc, (int, float))
+            and isinstance(new_soc, (int, float))
             and old_soc < new_soc
             and new_soc == c.CAR_MAX_SOC_IN_PERCENT
             and await self.evse_client_app.is_charging()

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_max_soc_notification.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_max_soc_notification.py
@@ -71,6 +71,19 @@ class TestMaxSocNotification:
         v2g.notifier.notify_user.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_no_notification_when_soc_becomes_unavailable_on_disconnect(
+        self, v2g
+    ):
+        """new_soc is "unavailable" (car just disconnected) → no notification and
+        no ``int < str`` TypeError from the max-SoC comparison."""
+        await _handle(
+            v2g,
+            new_soc="unavailable",
+            old_soc=c.CAR_MAX_SOC_IN_PERCENT - 1,
+        )
+        v2g.notifier.notify_user.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_no_notification_when_already_at_max(self, v2g):
         """No genuine rise (old_soc == new_soc == max) → no notification."""
         await _handle(


### PR DESCRIPTION
## Problem
On car disconnect the charger reports SoC as `"unavailable"`, so
`__handle_soc_change` gets `new_soc="unavailable"` while `old_soc` is still a
number. The "battery reached max SoC" gate guarded `old_soc` but not `new_soc`,
so `old_soc < new_soc` raised `TypeError: '<' not supported between instances of
'int' and 'str'` on every disconnect. Caught by the event bus (no crash, no
functional harm), but a warning in the log each disconnect. Surfaced during the
fase2a emulator log review.

## Fix
Add the symmetric `isinstance(new_soc, (int, float))` guard beside the existing
`old_soc` guard.

## Testing
- New regression test (proven: fails with the exact TypeError without the fix).
- ruff clean on the changed lines; full suite 1033 passed.
