### PR TITLE
Fix ttl-based notification clearing (unpack AppDaemon's kwargs dict)

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 🪲 BUG: Fix db schema validation (#470)
 - 🪲 BUG: Paused app lets the charger charge the car to full on reconnect (#480, #481)
 - 🪲 BUG: Guard the max-SoC notification against a non-numeric new SoC (#483)
+- 🪲 BUG: Fix ttl-based notification clearing (unpack AppDaemon's kwargs dict) - (#484)
 
 
 ### Added

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -11,6 +11,8 @@ That file also contains possible changes that the next release might include.
 - 🪲 BUG: Fix db schema validation (#470)
 - 🪲 BUG: Paused app lets the charger charge the car to full on reconnect (#480, #481)
 - 🪲 BUG: Guard the max-SoC notification against a non-numeric new SoC (#483)
+- 🪲 BUG: Fix ttl-based notification clearing (unpack AppDaemon's kwargs dict) - (#484)
+
 
 ### Added
 

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/notifier_util.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/notifier_util.py
@@ -165,7 +165,10 @@ class Notifier:
             # A tag is required for clearing.
             # Critical notifications should never auto clear.
             await self.hass.run_in(
-                self.clear_notification, delay=ttl, recipients=to_notify, tag=tag
+                self._clear_notification_after_ttl,
+                delay=ttl,
+                recipients=to_notify,
+                tag=tag,
             )
 
     def clear_notification(self, tag: str, recipients: Optional[list] = None):
@@ -198,6 +201,19 @@ class Notifier:
                 self.__log(
                     f"Could not clear notification: exception on {recipient}. Exception: {e}."
                 )
+
+    async def _clear_notification_after_ttl(self, kwargs: dict):
+        """Scheduled (``run_in``) callback that clears a notification after its ttl.
+
+        AppDaemon passes the scheduling kwargs as a single positional dict, so the
+        tag and recipients are read from it here. Scheduling ``clear_notification``
+        directly bound that whole dict to its ``tag`` parameter, so the ttl clear
+        never matched the real tag and the notification was never removed.
+        """
+        self.clear_notification(
+            tag=kwargs.get("tag"),
+            recipients=kwargs.get("recipients"),
+        )
 
     def post_sticky_memo(
         self, message: str, title: Optional[str] = None, memo_id: Optional[str] = None

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_notifier_util.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_notifier_util.py
@@ -7,9 +7,11 @@ from apps.v2g_liberty import constants as c
 from appdaemon.plugins.hass.hassapi import Hass
 from apps.v2g_liberty.event_bus import EventBus
 
+
 @pytest.fixture
 def event_bus():
     return AsyncMock(spec=EventBus)
+
 
 @pytest.fixture
 def mock_hass():
@@ -108,6 +110,41 @@ def test_clear_notification(notifier, mock_hass):
             ),
         ],
         any_order=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ttl_schedules_clear_via_wrapper(notifier, mock_hass):
+    """A ttl schedules the unpacking wrapper, not clear_notification directly.
+
+    Scheduling clear_notification directly made AppDaemon pass its kwargs as one
+    positional dict into the `tag` parameter, so the ttl clear never matched.
+    """
+    await notifier.notify_user(
+        message="Test message",
+        tag="mytag",
+        send_to_all=True,
+        ttl=900,
+    )
+    mock_hass.run_in.assert_awaited_once_with(
+        notifier._clear_notification_after_ttl,
+        delay=900,
+        recipients=["jane", "john"],
+        tag="mytag",
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_after_ttl_unpacks_kwargs(notifier, mock_hass):
+    """The scheduled ttl-clear reads tag/recipients from AppDaemon's single dict
+    and clears the real tag string (not the whole dict)."""
+    await notifier._clear_notification_after_ttl(
+        {"__thread_id": "thread-1", "recipients": ["jane"], "tag": "mytag"}
+    )
+    mock_hass.call_service.assert_called_once_with(
+        "notify/mobile_app_jane",
+        message="clear_notification",
+        data={"tag": "mytag"},
     )
 
 


### PR DESCRIPTION
## Problem
`notify_user` scheduled `clear_notification` via
`run_in(self.clear_notification, delay=ttl, recipients=..., tag=...)`. AppDaemon 4
passes a scheduled callback's kwargs as a single positional dict, so the whole
dict landed in `clear_notification`'s `tag` parameter — the ttl clear then targeted
a non-matching tag and the notification was never removed. Seen in the logs as
`tag={'__thread_id': ..., 'recipients': [...], 'tag': 'charger_disconnected'}`.
Surfaced during the fase2a emulator log review.

## Fix
Schedule a dedicated `_clear_notification_after_ttl(kwargs)` wrapper that reads
tag/recipients from AppDaemon's dict and calls `clear_notification`. Direct
synchronous callers are unaffected.

## Testing
- Two new tests (proven: both fail without the fix). ruff clean; full suite 1035 passed.
