### PR TITLE
Keep the FlexMeasures connection green when a single sensor is rejected

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -10,6 +10,7 @@
 - 🪲 BUG: Guard the max-SoC notification against a non-numeric new SoC (#483)
 - 🪲 BUG: Fix ttl-based notification clearing (unpack AppDaemon's kwargs dict) - (#484)
 - 🪲 BUG: Fix grid connection save fm gate - (#485)
+- 🪲 BUG: FlexMeasures connection wrongly shows "Error" when a single sensor's data is rejected (#486)
 
 
 ### Added

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -13,6 +13,7 @@ That file also contains possible changes that the next release might include.
 - 🪲 BUG: Guard the max-SoC notification against a non-numeric new SoC (#483)
 - 🪲 BUG: Fix ttl-based notification clearing (unpack AppDaemon's kwargs dict) - (#484)
 - 🪲 BUG: Fix grid connection save fm gate - (#485)
+- 🪲 BUG: FlexMeasures connection wrongly shows "Error" when a single sensor's data is rejected (#486)
 
 
 ### Added

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/fm_client.py
@@ -19,10 +19,54 @@ from .time_range_util import (
 )
 
 
+def _fm_http_status(exception: Exception) -> int | None:
+    """Extract the HTTP status code from a flexmeasures-client exception.
+
+    The client raises errors in two shapes:
+      - "Request failed with status code NNN"
+      - "Error occurred while communicating with the API: NNN, message=..."
+    Returns the status code as an int, or None when the exception carries no
+    HTTP status at all (transport error, timeout, DNS failure).
+    """
+    match = re.search(r"status code (\d{3})|API:\s*(\d{3})", str(exception))
+    if match is None:
+        return None
+    return int(match.group(1) or match.group(2))
+
+
+def _is_connection_error(exception: Exception) -> bool:
+    """Classify an exception as a connection/auth failure vs an operational
+    rejection of one specific request.
+
+    Returns True (the connection is down) for:
+      - no HTTP status at all (transport/timeout/DNS),
+      - a 5xx server error (FlexMeasures itself is failing),
+      - a 401 (token invalid, so the whole connection is unusable).
+    Returns False (the connection is up, only this request was refused) for
+    other 4xx such as 403/404/422: FlexMeasures is reachable but rejects this
+    specific action.
+    """
+    status = _fm_http_status(exception)
+    if status is None:
+        return True
+    if status >= 500:
+        return True
+    if status == 401:
+        return True
+    return False
+
+
 class FMClient(AsyncIOEventEmitter):
     """This class manages the communication with the FlexMeasures platform, which delivers the
     charging schedules.
-    - Reports on errors via v2g_liberty module handle_no_schedule()
+
+    Emits (via AsyncIOEventEmitter), handled in main_app:
+    - "no_new_schedule": a schedule could not be retrieved
+      (main_app.handle_no_new_schedule).
+    - "fm_data_issue": FlexMeasures is reachable but refuses data for a
+      specific sensor - an operational error, not a connection failure
+      (main_app.handle_fm_data_issue). kwargs: active (bool), and when active
+      also sensor_id (int) and detail (str). Raised from post_sensor_data.
     """
 
     event_bus: EventBus = None
@@ -93,6 +137,12 @@ class FMClient(AsyncIOEventEmitter):
         self.connection_error_counter = 0
         # self.run_every(self.ping_server, "now", 30 * 60)
         self.handle_for_repeater = ""
+
+        # Sensor ids whose data posts are currently rejected by FlexMeasures
+        # with an operational error (e.g. 403). Used to raise/clear a single
+        # persistent "fm_data_issue" warning without touching the connection
+        # status. See post_sensor_data / _clear_data_issue.
+        self._sensors_with_data_issue: set[int] = set()
 
     async def test_fm_connection(self, host_url, username, password):
         """Test if we can connect with given FlexMeasures host and port.
@@ -707,30 +757,68 @@ class FMClient(AsyncIOEventEmitter):
                 unit=uom,
             )
         except Exception as e:
-            # flexmeasures-client raises ValueError("Request failed with status
-            # code NNN") when the response status is not its single expected
-            # status. FlexMeasures returns 202 (Accepted) for sensor-data posts,
-            # which the client (0.8.1) does not whitelist. A 2xx status means the
-            # data was accepted by FM, so treat it as success rather than a
+            # flexmeasures-client raises on any status other than its single
+            # expected one. FlexMeasures returns 202 (Accepted) for sensor-data
+            # posts, which the client (0.8.1) does not whitelist. A 2xx status
+            # means the data was accepted, so treat it as success rather than a
             # failure (which would otherwise retry forever and flag FM as down).
-            match = re.search(r"status code (\d{3})", str(e))
-            if match and 200 <= int(match.group(1)) < 300:
+            status = _fm_http_status(e)
+            if status is not None and 200 <= status < 300:
                 self.__log(
-                    f"accepted (HTTP {match.group(1)}) | sensor_id: '{sensor_id}', "
+                    f"accepted (HTTP {status}) | sensor_id: '{sensor_id}', "
                     f"start: '{start}', duration: '{duration}', unit: '{uom}'.",
                     level="DEBUG",
                 )
+                self._clear_data_issue(sensor_id)
                 return True
+
+            if _is_connection_error(e):
+                # Transport/timeout/5xx/401: the connection itself is down.
+                self.__log(
+                    f"connection failed | sensor_id: '{sensor_id}', "
+                    f"values: '{values}', start: '{start}', duration: "
+                    f"'{duration}', unit: '{uom}', "
+                    f"fm_client returned exception: '{e}'.",
+                    level="WARNING",
+                )
+                await self.set_fm_connection_status(connected=False)
+                return False
+
+            # Operational 4xx (e.g. 403/404/422): FlexMeasures is reachable but
+            # refuses this specific post. Leave the connection status untouched
+            # and raise a persistent, actionable warning instead of a false
+            # "Error" that would wrongly mark the whole FM connection as down.
             self.__log(
-                f"failed | sensor_id: '{sensor_id}', values: '{values}', "
-                f"start: '{start}', duration: '{duration}', unit: '{uom}', "
-                f"fm_client returned exception: '{e}'.",
+                f"rejected (HTTP {status}) | sensor_id: '{sensor_id}', "
+                f"values: '{values}', start: '{start}', duration: '{duration}', "
+                f"unit: '{uom}', fm_client returned exception: '{e}'.",
                 level="WARNING",
             )
-            await self.set_fm_connection_status(connected=False)
+            self._sensors_with_data_issue.add(sensor_id)
+            self.emit(
+                "fm_data_issue",
+                active=True,
+                sensor_id=sensor_id,
+                detail=f"HTTP {status}",
+            )
             return False
 
+        self._clear_data_issue(sensor_id)
         return True
+
+    def _clear_data_issue(self, sensor_id: int):
+        """Mark a sensor's data post as healthy again.
+
+        When this clears the last sensor that had an operational issue, emit
+        "fm_data_issue" with active=False so the persistent warning is
+        dismissed. A silent no-op when the sensor had no issue, so the happy
+        path emits nothing.
+        """
+        if sensor_id not in self._sensors_with_data_issue:
+            return
+        self._sensors_with_data_issue.discard(sensor_id)
+        if not self._sensors_with_data_issue:
+            self.emit("fm_data_issue", active=False)
 
     async def get_new_schedule(
         self, targets: list, current_soc_kwh: float, back_to_max_soc: datetime

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/main_app.py
@@ -160,6 +160,7 @@ class V2Gliberty:
         self.no_schedule_notification_is_planned = False
 
         self.fm_client_app.add_listener("no_new_schedule", self.handle_no_new_schedule)
+        self.fm_client_app.add_listener("fm_data_issue", self.handle_fm_data_issue)
         self.fm_client_app.add_listener(
             "unreachable_target", self.handle_unreachable_target
         )
@@ -777,6 +778,33 @@ class V2Gliberty:
             tag="unreachable_target",
             send_to_all=True,
             ttl=ttl,
+        )
+
+    async def handle_fm_data_issue(
+        self, active: bool, sensor_id: int = None, detail: str = None
+    ):
+        """Show or dismiss a persistent memo when FlexMeasures is reachable but
+        refuses data for a specific sensor (an operational error, not a
+        connection failure). Emitted by fm_client.post_sensor_data.
+
+        The memo stays visible until the underlying post succeeds again (or the
+        user re-saves the grid/solar configuration to recreate the sensors).
+        To be called from fm_client_app.
+        """
+        if not active:
+            self.notifier.dismiss_sticky_memo(memo_id="fm_data_issue")
+            return
+        message = (
+            "V2G Liberty can reach FlexMeasures, but FlexMeasures refuses data "
+            f"for at least one sensor (sensor {sensor_id}, {detail}). This "
+            "usually means the sensor is still linked to a different "
+            "FlexMeasures asset. Please re-save the relevant grid- or "
+            "solar-panel configuration to recreate the sensors."
+        )
+        self.notifier.post_sticky_memo(
+            message=message,
+            title="FlexMeasures is refusing data",
+            memo_id="fm_data_issue",
         )
 
     async def handle_no_new_schedule(self, error_name: str, error_state: bool):

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/notifier_util.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/notifier_util.py
@@ -241,6 +241,23 @@ class Notifier:
         except Exception as e:
             self.__log(f"Failed. Exception: '{e}'.", level="WARNING")
 
+    def dismiss_sticky_memo(self, memo_id: str):
+        """
+        Dismiss a sticky memo (persistent notification) previously posted with
+        post_sticky_memo, identified by memo_id.
+
+        Args:
+            memo_id (str):
+                The id used when the memo was created via post_sticky_memo.
+        """
+        try:
+            self.hass.call_service(
+                service="persistent_notification/dismiss",
+                notification_id=memo_id,
+            )
+        except Exception as e:
+            self.__log(f"Failed. Exception: '{e}'.", level="WARNING")
+
     ########################################################################
     #                       PRIVATE (UTILITY) FUNCTIONS                    #
     ########################################################################

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_fm_client_post_sensor_data.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_fm_client_post_sensor_data.py
@@ -1,0 +1,208 @@
+"""Unit tests for FMClient.post_sensor_data error classification.
+
+A failed post to one sensor (e.g. a 403 for a stale/foreign sensor id) must not
+mark the whole FlexMeasures connection as down. Only genuine connection/auth
+failures (transport, timeout, 5xx, 401) set the connection status to down;
+operational 4xx (403/404/422) raise a persistent "fm_data_issue" warning while
+leaving the connection status untouched.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from apps.v2g_liberty.fm_client import (
+    FMClient,
+    _fm_http_status,
+    _is_connection_error,
+)
+
+# Arbitrary valid-looking arguments; the underlying client is mocked so the
+# exact values do not matter.
+_START = "2026-08-06T12:00:00+02:00"
+_DURATION = "PT5M"
+_UOM = "kW"
+_SENSOR_ID = 531
+
+
+@pytest.fixture
+def hass_mock():
+    mock = AsyncMock()
+    mock.log = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def fm(hass_mock):
+    """Create FMClient with the parts post_sensor_data touches mocked out."""
+    with patch("apps.v2g_liberty.fm_client.isodate"):
+        client = FMClient(hass_mock, MagicMock())
+    client.client = AsyncMock()
+    client.set_fm_connection_status = AsyncMock()
+    client.emit = MagicMock()
+    return client
+
+
+async def _post(fm, sensor_id=_SENSOR_ID):
+    return await fm.post_sensor_data(
+        sensor_id=sensor_id,
+        values=[1.0],
+        start=_START,
+        duration=_DURATION,
+        uom=_UOM,
+    )
+
+
+class TestFmHttpStatus:
+    @pytest.mark.parametrize(
+        "message, expected",
+        [
+            ("Request failed with status code 403", 403),
+            (
+                "Error occurred while communicating with the API: 403, message=x",
+                403,
+            ),
+            ("Request failed with status code 502", 502),
+            ("Something failed with status code 202", 202),
+            ("Cannot connect to host example.com:443", None),
+            ("Timeout while reading", None),
+        ],
+    )
+    def test_parses_both_formats(self, message, expected):
+        assert _fm_http_status(Exception(message)) == expected
+
+
+class TestIsConnectionError:
+    @pytest.mark.parametrize(
+        "message, is_connection",
+        [
+            ("Request failed with status code 403", False),
+            ("Request failed with status code 404", False),
+            ("Request failed with status code 422", False),
+            (
+                "Error occurred while communicating with the API: 403, message=x",
+                False,
+            ),
+            ("Request failed with status code 401", True),
+            ("Request failed with status code 500", True),
+            ("Request failed with status code 502", True),
+            ("Cannot connect to host", True),
+        ],
+    )
+    def test_classification(self, message, is_connection):
+        assert _is_connection_error(Exception(message)) is is_connection
+
+
+class TestPostSensorDataClassification:
+    @pytest.mark.asyncio
+    async def test_operational_403_does_not_mark_connection_down(self, fm):
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 403")
+        )
+        result = await _post(fm)
+        assert result is False
+        fm.set_fm_connection_status.assert_not_called()
+        fm.emit.assert_called_once_with(
+            "fm_data_issue", active=True, sensor_id=_SENSOR_ID, detail="HTTP 403"
+        )
+        assert _SENSOR_ID in fm._sensors_with_data_issue
+
+    @pytest.mark.asyncio
+    async def test_operational_403_api_format(self, fm):
+        # The "API: NNN" wording is the exact shape the original bug slipped
+        # through (the old 2xx regex only matched "status code NNN").
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=Exception(
+                "Error occurred while communicating with the API: 403, "
+                "message='Forbidden'"
+            )
+        )
+        result = await _post(fm)
+        assert result is False
+        fm.set_fm_connection_status.assert_not_called()
+        fm.emit.assert_called_once_with(
+            "fm_data_issue", active=True, sensor_id=_SENSOR_ID, detail="HTTP 403"
+        )
+
+    @pytest.mark.asyncio
+    async def test_5xx_marks_connection_down(self, fm):
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 502")
+        )
+        result = await _post(fm)
+        assert result is False
+        fm.set_fm_connection_status.assert_called_once_with(connected=False)
+        fm.emit.assert_not_called()
+        assert _SENSOR_ID not in fm._sensors_with_data_issue
+
+    @pytest.mark.asyncio
+    async def test_401_marks_connection_down(self, fm):
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 401")
+        )
+        result = await _post(fm)
+        assert result is False
+        fm.set_fm_connection_status.assert_called_once_with(connected=False)
+        fm.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transport_error_marks_connection_down(self, fm):
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=ConnectionError("Cannot connect to host example.com")
+        )
+        result = await _post(fm)
+        assert result is False
+        fm.set_fm_connection_status.assert_called_once_with(connected=False)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Request failed with status code 202",
+            "Error occurred while communicating with the API: 202, message=ok",
+        ],
+    )
+    async def test_202_accepted_is_success(self, fm, message):
+        fm.client.post_sensor_data = AsyncMock(side_effect=ValueError(message))
+        result = await _post(fm)
+        assert result is True
+        fm.set_fm_connection_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success_for_healthy_sensor_emits_nothing(self, fm):
+        # No exception -> normal success; the happy path must stay silent.
+        result = await _post(fm)
+        assert result is True
+        fm.emit.assert_not_called()
+        fm.set_fm_connection_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success_after_403_clears_the_issue(self, fm):
+        # First post is rejected (403) -> issue raised.
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 403")
+        )
+        await _post(fm)
+        assert _SENSOR_ID in fm._sensors_with_data_issue
+        fm.emit.reset_mock()
+
+        # A later post for the same sensor succeeds -> issue cleared.
+        fm.client.post_sensor_data = AsyncMock(return_value=None)
+        result = await _post(fm)
+        assert result is True
+        assert _SENSOR_ID not in fm._sensors_with_data_issue
+        fm.emit.assert_called_once_with("fm_data_issue", active=False)
+
+    @pytest.mark.asyncio
+    async def test_other_healthy_sensor_keeps_issue_active(self, fm):
+        # Sensor 531 keeps failing; a *different* healthy sensor succeeding must
+        # not dismiss the warning while 531 is still failing.
+        fm.client.post_sensor_data = AsyncMock(
+            side_effect=ValueError("Request failed with status code 403")
+        )
+        await _post(fm, sensor_id=531)
+        fm.emit.reset_mock()
+
+        fm.client.post_sensor_data = AsyncMock(return_value=None)
+        await _post(fm, sensor_id=999)
+        assert 531 in fm._sensors_with_data_issue
+        fm.emit.assert_not_called()

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_fm_data_issue.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_main_app_fm_data_issue.py
@@ -1,0 +1,41 @@
+"""Unit tests for main_app.handle_fm_data_issue.
+
+Shows/dismisses a persistent memo when FlexMeasures is reachable but refuses
+data for a specific sensor (an operational error, not a connection failure),
+mirroring how fm_client.post_sensor_data reports the condition.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from apps.v2g_liberty.main_app import V2Gliberty
+
+
+@pytest.fixture
+def v2g():
+    """Create V2Gliberty with a mocked notifier."""
+    hass = AsyncMock()
+    hass.log = MagicMock()
+    notifier = MagicMock()
+    return V2Gliberty(hass=hass, event_bus=MagicMock(), notifier=notifier)
+
+
+class TestHandleFmDataIssue:
+    @pytest.mark.asyncio
+    async def test_active_posts_sticky_memo(self, v2g):
+        await v2g.handle_fm_data_issue(active=True, sensor_id=531, detail="HTTP 403")
+
+        v2g.notifier.post_sticky_memo.assert_called_once()
+        kwargs = v2g.notifier.post_sticky_memo.call_args.kwargs
+        assert kwargs["memo_id"] == "fm_data_issue"
+        assert "531" in kwargs["message"]
+        v2g.notifier.dismiss_sticky_memo.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inactive_dismisses_sticky_memo(self, v2g):
+        await v2g.handle_fm_data_issue(active=False)
+
+        v2g.notifier.dismiss_sticky_memo.assert_called_once_with(
+            memo_id="fm_data_issue"
+        )
+        v2g.notifier.post_sticky_memo.assert_not_called()

--- a/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_notifier_util.py
+++ b/v2g-liberty/rootfs/root/appdaemon/tests/v2g_liberty/test_notifier_util.py
@@ -163,3 +163,13 @@ def test_post_sticky_memo(notifier, mock_hass):
         message="Sticky memo test",
         notification_id="sticky_id",
     )
+
+
+def test_dismiss_sticky_memo(notifier, mock_hass):
+    """Test dismiss_sticky_memo dismisses the persistent notification by id."""
+    notifier.dismiss_sticky_memo(memo_id="fm_data_issue")
+
+    mock_hass.call_service.assert_called_with(
+        service="persistent_notification/dismiss",
+        notification_id="fm_data_issue",
+    )


### PR DESCRIPTION
## Summary

A single sensor's data post being rejected by FlexMeasures (e.g. HTTP 403 on a stale/foreign sensor id) no longer marks the **whole** FlexMeasures connection as `Error`. The connection status now reflects genuine connectivity only; an operational rejection of one post raises a persistent, actionable warning instead.

## Problem

`post_sensor_data` treated **every** non-2xx response as "connection lost" and called `set_fm_connection_status(connected=False)`. So one rejected sensor post — for example PV data sent to a stale sensor from an older FM account (HTTP 403 `FORBIDDEN`) — flipped the global status to `Error`, even though FlexMeasures was perfectly reachable (token OK, `get_assets` OK, grid posts OK). The sender retried every cycle, so the false `Error` never cleared on its own.

Two distinct concerns were conflated:

- **Connectivity / auth** — "can we reach FM at all?" (transport, timeout, 5xx, 401).
- **Operational rejection** — "FM is reachable but refuses this specific action" (403/404/422 on one sensor).

A `403` on one sensor is the second, but was reported as the first.

## Fix

`post_sensor_data` now classifies the exception:

- **Connection error** (no HTTP status → transport/timeout/DNS, or 5xx, or 401) → `set_fm_connection_status(connected=False)`, as before.
- **Operational 4xx** (403/404/422) → connection status is left untouched; a persistent HA memo ("FlexMeasures is refusing data…") is raised via a new `fm_data_issue` event, and dismissed automatically on the next successful post for that sensor.

Also fixes the 2xx-detection regex: the client raises errors in two shapes, and the previous `status code (\d{3})` pattern did not match the `Error occurred while communicating with the API: NNN` form — exactly the shape the observed 403 arrived in.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| 403/404/422 on one sensor's post | Whole FM connection shows `Error` (misleading, never clears) | Connection stays green; persistent actionable memo shown, self-clears on recovery |
| Transport/timeout/5xx/401 | Connection `Error` | Connection `Error` (unchanged) |

## Changes

- `fm_client.py` — `_fm_http_status` + `_is_connection_error` helpers; `post_sensor_data` classification + 2xx-regex fix; emits `fm_data_issue`; `_clear_data_issue` self-clear (tracks failing sensor ids so the memo stays up while any sensor is rejected).
- `main_app.py` — `handle_fm_data_issue` listener that shows/dismisses the sticky memo (mirrors the `no_new_schedule` pattern).
- `notifier_util.py` — `dismiss_sticky_memo` to clear a persistent notification by id.
- Tests — `test_fm_client_post_sensor_data.py`, `test_main_app_fm_data_issue.py`, plus additions to `test_notifier_util.py`.

## Testing

- Full suite: **1076 passed**.
- Live-verified against the dev environment (real FM staging + emulated PV): the 403 on the stale sensor is logged as `rejected (HTTP 403)`, `fm_connection_status` stays `Successfully connected`, and the persistent memo is shown in HA. Restoring a valid sensor dismisses the memo on the next successful post.
