### PR TITLE
Bump FlexMeasures Client to 0.9.5

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Changed
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
+- ⬆️ Bump flexmeasures-client to 0.9.5 for poll-based schedule retrieval (robust against FlexMeasures returning 202/"in progress" for schedules)
 
 #### Removing
 

--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Changed
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
-- ⬆️ Bump flexmeasures-client to 0.9.5 for poll-based schedule retrieval (robust against FlexMeasures returning 202/"in progress" for schedules)
+- ⬆️ Bump flexmeasures-client to 0.9.5 (#489)
 
 #### Removing
 
@@ -34,5 +34,6 @@
 
 To keep things readable here a separate document is maintained
 with [the complete list of all changes for all past releases](changelog_of_all_releases.md).
+
 
 &nbsp;

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -27,7 +27,7 @@ That file also contains possible changes that the next release might include.
 ### Changed
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
-- ⬆️ Bump flexmeasures-client to 0.9.5 for poll-based schedule retrieval (robust against FlexMeasures returning 202/"in progress" for schedules)
+- ⬆️ Bump flexmeasures-client to 0.9.5 (#489)
 
 
 ## 0.8.2 2026-06-19

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -27,6 +27,7 @@ That file also contains possible changes that the next release might include.
 ### Changed
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
+- ⬆️ Bump flexmeasures-client to 0.9.5 for poll-based schedule retrieval (robust against FlexMeasures returning 202/"in progress" for schedules)
 
 
 ## 0.8.2 2026-06-19

--- a/v2g-liberty/requirements.txt
+++ b/v2g-liberty/requirements.txt
@@ -2,7 +2,7 @@ appdaemon==4.5.11
 isodate==0.6.1
 pymodbus==3.11.4
 caldav==1.4.0
-flexmeasures-client==0.8.1
+flexmeasures-client==0.9.5
 pyee==12.1.1
 
 # Work around for https://github.com/hassio-addons/addon-appdaemon/issues/345


### PR DESCRIPTION
## Summary

Bumps `flexmeasures-client` from **0.8.1 → 0.9.5** in `requirements.txt`, for
**poll-based schedule retrieval**: the 0.9.5 client polls a still-computing
schedule (FlexMeasures signals "in progress" via HTTP 202 on older servers, or
HTTP 400 `STARTED` on FlexMeasures 1.0) through to `200` and a real schedule,
instead of treating the interim status as an error.

**No `fm_client.py` code change is required** — every client call V2G Liberty
uses stays backward-compatible in 0.9.5.

## What changed

- `requirements.txt`: `flexmeasures-client==0.8.1` → `0.9.5`
