### PR TITLE
Harden shared Modbus client: retries=0 and 10s timeout

### DIFF
--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
 - ⬆️ Bump flexmeasures-client to 0.9.5 (#489)
+- 🛠️ Harden the shared Modbus client: retries=0 and a 10s timeout to avoid transaction-id desync on slow chargers
 
 #### Removing
 

--- a/v2g-liberty/CHANGELOG.md
+++ b/v2g-liberty/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
 - ⬆️ Bump flexmeasures-client to 0.9.5 (#489)
-- 🛠️ Harden the shared Modbus client: retries=0 and a 10s timeout to avoid transaction-id desync on slow chargers
+- 🛠️ Harden shared Modbus client: retries=0 and 10s timeout - (#490)
 
 #### Removing
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -28,8 +28,7 @@ That file also contains possible changes that the next release might include.
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
 - ⬆️ Bump flexmeasures-client to 0.9.5 (#489)
-- 🛠️ Harden the shared Modbus client: retries=0 and a 10s timeout to avoid transaction-id desync on slow chargers
-
+- 🛠️ Harden shared Modbus client: retries=0 and 10s timeout - (#490)
 
 ## 0.8.2 2026-06-19
 

--- a/v2g-liberty/changelog_of_all_releases.md
+++ b/v2g-liberty/changelog_of_all_releases.md
@@ -28,6 +28,7 @@ That file also contains possible changes that the next release might include.
 
 - Explain the 'charger phase not set' warning and keep it in sync (#474)
 - ⬆️ Bump flexmeasures-client to 0.9.5 (#489)
+- 🛠️ Harden the shared Modbus client: retries=0 and a 10s timeout to avoid transaction-id desync on slow chargers
 
 
 ## 0.8.2 2026-06-19

--- a/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/chargers/v2g_modbus_client.py
+++ b/v2g-liberty/rootfs/root/appdaemon/apps/v2g_liberty/chargers/v2g_modbus_client.py
@@ -88,9 +88,18 @@ class V2GmodbusClient(AsyncIOEventEmitter):
             return None
 
         try:
+            # retries=0 is required: after a timeout the charger's late duplicate
+            # response desynchronises pymodbus's transaction-id stream, so every
+            # subsequent read returns the previous request's answer until the
+            # socket is dropped. Fail cleanly and reconnect instead. The timeout is
+            # generous because some chargers (e.g. EVtec BiDiPro) stall for several
+            # seconds. Unit/slave id stays configurable per register via
+            # MBR.device_id (default 1).
             client = amtc(
                 host=host,
                 port=port,
+                retries=0,
+                timeout=10,
             )
             await client.connect()
         except ModbusException as me:


### PR DESCRIPTION
## Summary

Configure the shared Modbus client (`chargers/v2g_modbus_client.py`) explicitly
instead of relying on pymodbus defaults: **`retries=0`** and a **10 s timeout**.

## Why

With auto-retries (pymodbus default ≈ 3), a charger's *late* duplicate response
after a timeout desynchronises pymodbus's transaction-id stream — after which
every subsequent read returns the **previous** request's answer until the socket
is dropped. Setting `retries=0` makes a timed-out request fail cleanly so the
client reconnects instead. The timeout is raised from the default (~3 s) to a
generous **10 s** because some chargers can stall for several seconds.

## What changed

- `chargers/v2g_modbus_client.py` — `__create_client` now passes `retries=0` and
  `timeout=10` to `AsyncModbusTcpClient`, with a comment explaining the desync.
- `CHANGELOG.md` + `changelog_of_all_releases.md` — entry under **Changed**.

Unit/slave id is intentionally **not** made globally configurable here: it is
already configurable per register via `MBR.device_id` (default 1), so a second
mechanism would be redundant.